### PR TITLE
feat: flatmates matching/profiles enhancements and property search updates

### DIFF
--- a/app/api/api_v1/endpoints/flatmates.py
+++ b/app/api/api_v1/endpoints/flatmates.py
@@ -52,6 +52,7 @@ from app.services.flatmates import (
     list_incoming_likes,
     list_matches,
     list_messages,
+    list_outgoing_likes,
     mark_all_flatmates_notifications_read,
     mark_conversation_read,
     mark_flatmates_notification_read,
@@ -190,6 +191,16 @@ async def get_incoming_likes(
     db: AsyncSession = Depends(get_db),
 ):
     return await list_incoming_likes(db, current_user.id, limit=limit, offset=offset)
+
+
+@router.get("/outgoing-likes", response_model=list[IncomingLikeSummary])
+async def get_outgoing_likes(
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    current_user: UserSchema = Depends(get_current_active_user),
+    db: AsyncSession = Depends(get_db),
+):
+    return await list_outgoing_likes(db, current_user.id, limit=limit, offset=offset)
 
 
 @router.post("/profile-views", response_model=ProfileViewEventOut)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -106,10 +106,10 @@ class Settings(BaseSettings):
     REDIS_URL: str = "redis://localhost:6379"
 
     # Main pool (HTTP/MCP request traffic)
-    DB_POOL_SIZE: int = 3
-    DB_MAX_OVERFLOW: int = 3
-    DB_POOL_TIMEOUT: int = 10
-    DB_POOL_RECYCLE: int = 300
+    DB_POOL_SIZE: int = 5
+    DB_MAX_OVERFLOW: int = 5
+    DB_POOL_TIMEOUT: int = 15
+    DB_POOL_RECYCLE: int = 180
     # Background pool (schedulers, scrapers, long-running tasks)
     DB_BG_POOL_SIZE: int = 2
     DB_BG_MAX_OVERFLOW: int = 2

--- a/app/services/flatmates/__init__.py
+++ b/app/services/flatmates/__init__.py
@@ -19,6 +19,7 @@ from app.services.flatmates.interactions import (
 from app.services.flatmates.matching import (
     list_incoming_likes,
     list_matches,
+    list_outgoing_likes,
     record_swipe,
     unmatch_match,
     unmatch_user_pair,
@@ -60,6 +61,7 @@ __all__ = [
     # matching
     "record_swipe",
     "list_incoming_likes",
+    "list_outgoing_likes",
     "list_matches",
     "unmatch_user_pair",
     "unmatch_match",

--- a/app/services/flatmates/matching.py
+++ b/app/services/flatmates/matching.py
@@ -20,7 +20,7 @@ from app.models.enums import (
     UserMatchStatus,
 )
 from app.models.properties import Property
-from app.models.social import FlatmateSuperLikeUsage, UserConversation, UserMatch
+from app.models.social import FlatmateSuperLikeUsage, UserBlock, UserConversation, UserMatch
 from app.models.users import User, UserSwipe
 from app.schemas.flatmates import SwipeRequest
 from app.services.flatmates.conversations import _ensure_conversation
@@ -332,9 +332,19 @@ async def list_outgoing_likes(
     )
     outgoing_swipes = list((await db.execute(stmt)).scalars().all())
 
+    blocked_ids_stmt = select(UserBlock.blocked_user_id).where(
+        UserBlock.blocker_user_id == user_id,
+    )
+    blocker_ids_stmt = select(UserBlock.blocker_user_id).where(
+        UserBlock.blocked_user_id == user_id,
+    )
+    blocked_ids = set((await db.execute(blocked_ids_stmt)).scalars().all())
+    blocker_ids = set((await db.execute(blocker_ids_stmt)).scalars().all())
+    excluded_ids = blocked_ids | blocker_ids
+
     items: list[dict[str, Any]] = []
     for swipe in outgoing_swipes:
-        if swipe.target_user is None or await _is_blocked(db, user_id, swipe.target_user_id):
+        if swipe.target_user is None or swipe.target_user_id in excluded_ids:
             continue
         items.append(
             {

--- a/app/services/flatmates/matching.py
+++ b/app/services/flatmates/matching.py
@@ -308,6 +308,45 @@ async def list_incoming_likes(
     return items
 
 
+async def list_outgoing_likes(
+    db: AsyncSession,
+    user_id: int,
+    *,
+    limit: int = 20,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    """Return profiles the current user has liked (outgoing likes)."""
+    current_user = await db.get(User, user_id)
+    stmt = (
+        select(UserSwipe)
+        .options(selectinload(UserSwipe.target_user), selectinload(UserSwipe.context_property))
+        .where(
+            UserSwipe.user_id == user_id,
+            UserSwipe.target_type == SwipeTargetType.user.value,
+            UserSwipe.is_liked.is_(True),
+            UserSwipe.target_user_id.is_not(None),
+        )
+        .order_by(UserSwipe.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    outgoing_swipes = list((await db.execute(stmt)).scalars().all())
+
+    items: list[dict[str, Any]] = []
+    for swipe in outgoing_swipes:
+        if swipe.target_user is None or await _is_blocked(db, user_id, swipe.target_user_id):
+            continue
+        items.append(
+            {
+                "id": swipe.id,
+                "peer": _build_peer_payload(swipe.target_user, current_user),
+                "context_property": _build_property_context(swipe.context_property),
+                "created_at": swipe.created_at,
+            }
+        )
+    return items
+
+
 async def list_matches(db: AsyncSession, user_id: int) -> list[dict[str, Any]]:
     current_user = await db.get(User, user_id)
     stmt = (

--- a/app/services/flatmates/profiles.py
+++ b/app/services/flatmates/profiles.py
@@ -66,6 +66,7 @@ async def list_discoverable_profiles(
     offset: int = 0,
 ) -> list[dict[str, Any]]:
     from app.models.social import UserBlock  # noqa: WPS433 – avoid top-level circular risk
+    from app.models.users import UserSwipe
 
     blocked_stmt = select(UserBlock.blocked_user_id).where(
         UserBlock.blocker_user_id == user_id,
@@ -76,6 +77,12 @@ async def list_discoverable_profiles(
     blocked_ids = list((await db.execute(blocked_stmt)).scalars().all())
     blocker_ids = list((await db.execute(blocker_stmt)).scalars().all())
     excluded = {user_id, *blocked_ids, *blocker_ids}
+
+    swiped_subq = select(UserSwipe.target_user_id).where(
+        UserSwipe.user_id == user_id,
+        UserSwipe.target_type == "user",
+        UserSwipe.target_user_id.is_not(None),
+    )
 
     # --- Deal-breaker (non-negotiables) filtering (P0-4) ---
     requesting_user = await db.get(User, user_id)
@@ -89,6 +96,7 @@ async def list_discoverable_profiles(
 
     filters = [
         User.id.notin_(excluded),
+        User.id.notin_(swiped_subq),
         User.flatmates_onboarding_completed.is_(True),
         User.flatmates_profile_status == FlatmatesProfileStatus.active,
     ]

--- a/app/services/flatmates/profiles.py
+++ b/app/services/flatmates/profiles.py
@@ -15,10 +15,11 @@ from app.models.enums import (
     FlatmatesProfileStatus,
     PropertyPurpose,
     PropertyType,
+    SwipeTargetType,
 )
 from app.models.properties import Property
 from app.models.social import AppCatalog, UserConversation, UserMessage
-from app.models.users import User
+from app.models.users import User, UserSwipe
 from app.schemas.flatmates import FlatmatesProfileUpdate
 from app.services.flatmates.helpers import (
     _build_peer_payload,
@@ -66,7 +67,6 @@ async def list_discoverable_profiles(
     offset: int = 0,
 ) -> list[dict[str, Any]]:
     from app.models.social import UserBlock  # noqa: WPS433 – avoid top-level circular risk
-    from app.models.users import UserSwipe
 
     blocked_stmt = select(UserBlock.blocked_user_id).where(
         UserBlock.blocker_user_id == user_id,
@@ -80,7 +80,7 @@ async def list_discoverable_profiles(
 
     swiped_subq = select(UserSwipe.target_user_id).where(
         UserSwipe.user_id == user_id,
-        UserSwipe.target_type == "user",
+        UserSwipe.target_type == SwipeTargetType.user.value,
         UserSwipe.target_user_id.is_not(None),
     )
 

--- a/app/services/property/search.py
+++ b/app/services/property/search.py
@@ -589,17 +589,23 @@ async def get_unified_properties_optimized(
         if has_additional_columns:
             rows = result.all()
             for row in rows:
-                mapping = row._mapping if hasattr(row, "_mapping") else {}
-                prop = mapping.get("Property") or mapping.get(Property)
-                if prop is None:
-                    prop = row[0] if isinstance(row, tuple) and len(row) > 0 else row
-                if mapping and prop:
-                    if "distance_km" in mapping and mapping["distance_km"] is not None:
-                        prop.distance_km = mapping["distance_km"]
-                    if "vector_distance" in mapping and mapping["vector_distance"] is not None:
-                        prop.vector_distance = mapping["vector_distance"]
-                    if "relevance_score" in mapping and mapping["relevance_score"] is not None:
-                        prop.relevance_score = mapping["relevance_score"]
+                prop = row[0]
+                if not isinstance(prop, Property):
+                    mapping = row._mapping if hasattr(row, "_mapping") else {}
+                    prop = mapping.get("Property") or mapping.get(Property)
+                    if prop is None:
+                        prop = row[0] if isinstance(row, tuple) and len(row) > 0 else row
+                if isinstance(prop, Property):
+                    try:
+                        mapping = row._mapping if hasattr(row, "_mapping") else {}
+                        if "distance_km" in mapping and mapping["distance_km"] is not None:
+                            prop.distance_km = float(mapping["distance_km"])
+                        if "vector_distance" in mapping and mapping["vector_distance"] is not None:
+                            prop.vector_distance = float(mapping["vector_distance"])
+                        if "relevance_score" in mapping and mapping["relevance_score"] is not None:
+                            prop.relevance_score = float(mapping["relevance_score"])
+                    except (TypeError, ValueError, KeyError):
+                        pass
                 if prop:
                     properties.append(cast(Property, prop))  # type: ignore[arg-type]
         else:

--- a/app/services/property/search.py
+++ b/app/services/property/search.py
@@ -604,8 +604,8 @@ async def get_unified_properties_optimized(
                             prop.vector_distance = float(mapping["vector_distance"])
                         if "relevance_score" in mapping and mapping["relevance_score"] is not None:
                             prop.relevance_score = float(mapping["relevance_score"])
-                    except (TypeError, ValueError, KeyError):
-                        pass
+                    except (TypeError, ValueError, KeyError) as exc:
+                        logger.debug("Failed to cast property score fields: %s", exc)
                 if prop:
                     properties.append(cast(Property, prop))  # type: ignore[arg-type]
         else:


### PR DESCRIPTION
## Summary
- Add outgoing likes endpoint and service to track profiles the current user has liked
- Exclude already-swiped profiles from discoverable list to prevent duplicate suggestions
- Harden property search result mapping with type-safe float conversions and error handling
- Tune DB pool sizes for better production performance (pool 3->5, timeout 10->15s, recycle 300->180s)

## Changes
- **New endpoint**: GET /flatmates/outgoing-likes - returns profiles the user has liked
- **Matching service**: added list_outgoing_likes function with proper blocked user filtering
- **Profile discovery**: filters out users already swiped by current user
- **Property search**: safer extraction of distance_km, vector_distance, relevance_score with float() conversion and exception handling
- **Config**: increased DB pool size and timeout, reduced recycle interval for PgBouncer compatibility

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an endpoint to view profiles you’ve liked and updates discovery to hide already-swiped users. Fixes an N+1 in outgoing likes, improves property search casting with debug logging, and tunes DB pool settings for steadier production performance.

- **New Features**
  - GET /flatmates/outgoing-likes returns profiles the current user liked, with block filtering and paging.
  - Discovery excludes users you’ve already swiped.

- **Refactors**
  - Outgoing likes: removed N+1 by prefetching block lists; cleaned imports; use `SwipeTargetType` enum.
  - Property search: cast distance_km, vector_distance, relevance_score to float; log cast errors at debug.
  - DB config: pool size 5, max overflow 5, timeout 15s, recycle 180s.

<sup>Written for commit 55112a8189f40d3ffb5308f859345005f0867e43. Summary will update on new commits. <a href="https://cubic.dev/pr/360ghar/backend/pull/14?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability for users to view their outgoing likes

* **Bug Fixes & Improvements**
  * Improved profile discovery to exclude previously swiped profiles
  * Enhanced search result handling for robustness
  * Optimized database connection pooling for better performance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/360ghar/backend/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a GET `/flatmates/outgoing-likes` endpoint so users can see who they've liked, filters out already-swiped profiles from discovery, hardens property-search row extraction with `float()` casts and try/except, and tunes DB pool settings for production.

- **New outgoing-likes endpoint**: `list_outgoing_likes` correctly batches block lookups into two queries rather than per-row calls, avoiding the N+1 pattern that still exists in `list_incoming_likes`.
- **Discovery filtering**: `swiped_subq` is a SQL subquery applied at the DB level, so pagination of discoverable profiles remains correct; the filter intentionally excludes both likes and dislikes.
- **Property-search hardening**: `float()` wrapping and exception handling prevents score-field parse errors from breaking the response; the `prop = row[0]` fast path is a reasonable optimization for the common case.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are additive or defensive, with no correctness regressions on existing paths.

The new outgoing-likes function correctly batches block queries, the discovery filter is applied as a SQL subquery so main-list pagination is unaffected, and the property-search hardening only adds safety around score-field extraction. The only notable trade-off is that paginated block-filtering in Python can return short pages, but that is a pre-existing pattern also present in list_incoming_likes and not a new regression.

app/services/flatmates/matching.py — the pagination behaviour under block filtering is worth a follow-up, particularly if blocked-user counts grow in production.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/services/flatmates/matching.py | Adds list_outgoing_likes with batched block queries; pagination applied before block filtering can cause pages to silently return fewer items than requested when blocked users are present. |
| app/services/flatmates/profiles.py | Adds SQL subquery to exclude all previously-swiped profiles from discovery; uses SwipeTargetType.user.value correctly and applies filter at DB level so pagination is unaffected. |
| app/services/property/search.py | Hardens row-extraction with row[0] fast path, float() casts, and try/except with debug logging; bad score values are now silently skipped without breaking the property list. |
| app/api/api_v1/endpoints/flatmates.py | Adds /outgoing-likes endpoint with standard query params; response_model reuse concern already flagged in a previous thread. |
| app/core/config.py | Increases pool_size/max_overflow to 5, timeout to 15s, reduces recycle to 180s for PgBouncer compatibility; straightforward config change. |
| app/services/flatmates/__init__.py | Exports list_outgoing_likes in both import and __all__; no issues. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Router as flatmates.py (router)
    participant SvcOut as list_outgoing_likes
    participant SvcDisc as list_discoverable_profiles
    participant DB

    Client->>Router: "GET /outgoing-likes?limit&offset"
    Router->>SvcOut: list_outgoing_likes(db, user_id)
    SvcOut->>DB: "SELECT UserSwipe WHERE user_id=X AND is_liked=True (paged)"
    SvcOut->>DB: "SELECT blocked_user_id WHERE blocker=user_id"
    SvcOut->>DB: "SELECT blocker_user_id WHERE blocked=user_id"
    SvcOut-->>Router: filtered list[dict] (excluded_ids removed in Python)
    Router-->>Client: list[IncomingLikeSummary]

    Client->>Router: GET /discover
    Router->>SvcDisc: list_discoverable_profiles(db, user_id)
    SvcDisc->>DB: SELECT blocked/blocker ids
    SvcDisc->>DB: SELECT User WHERE id NOT IN (swiped_subq) AND id NOT IN (excluded) paged
    SvcDisc-->>Router: paginated profiles
    Router-->>Client: list[profile]
```

<sub>Reviews (2): Last reviewed commit: ["fix: address PR review comments - import..."](https://github.com/360ghar/backend/commit/55112a8189f40d3ffb5308f859345005f0867e43) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32427651)</sub>

<!-- /greptile_comment -->