### PR TITLE
fix: dashboard activity endpoint resilience and schema enrichment

### DIFF
--- a/app/schemas/pm_dashboard.py
+++ b/app/schemas/pm_dashboard.py
@@ -18,6 +18,8 @@ class ActivityItem(BaseModel):
     type: str
     at: str
     id: int | None = None
+    title: str | None = None
+    message: str | None = None
     property_id: int | None = None
     lease_id: int | None = None
     amount: float | None = None

--- a/app/services/pm_dashboard.py
+++ b/app/services/pm_dashboard.py
@@ -7,13 +7,17 @@ from typing import Any
 from sqlalchemy import and_, exists, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.db_resilience import execute_with_transient_retry
 from app.core.exceptions import InsufficientPermissionsError
+from app.core.logging import get_logger
 from app.models.enums import LeaseStatus, UserRole
 from app.models.pm_finance import Expense, RentCharge, RentPayment
 from app.models.pm_leases import Lease
 from app.models.pm_maintenance import MaintenanceRequest
 from app.models.properties import Property
 from app.models.users import User
+
+logger = get_logger(__name__)
 
 
 async def _resolve_owner_scope(
@@ -156,12 +160,14 @@ async def get_recent_activity(
 
     activities: list[dict[str, Any]] = []
 
+    pay_stmt = select(RentPayment).order_by(RentPayment.paid_at.desc()).limit(limit)
+    if owner_ids is not None:
+        pay_stmt = pay_stmt.where(RentPayment.owner_id.in_(owner_ids))
     try:
-        pay_stmt = select(RentPayment).order_by(RentPayment.paid_at.desc()).limit(limit)
-        if owner_ids is not None:
-            pay_stmt = pay_stmt.where(RentPayment.owner_id.in_(owner_ids))
-        payments = list((await db.execute(pay_stmt)).scalars().all())
-        for p in payments:
+        pay_result = await execute_with_transient_retry(
+            db, operation=lambda: db.execute(pay_stmt), operation_name="fetch_rent_payments",
+        )
+        for p in pay_result.scalars().all():
             activities.append(
                 {
                     "type": "rent_payment",
@@ -175,15 +181,16 @@ async def get_recent_activity(
                 }
             )
     except Exception as e:
-        import logging
-        logging.getLogger(__name__).error("Failed to fetch rent payments for activity: %s", e)
+        logger.error("Failed to fetch rent payments for activity: %s", e)
 
+    maint_stmt = select(MaintenanceRequest).order_by(MaintenanceRequest.created_at.desc()).limit(limit)
+    if owner_ids is not None:
+        maint_stmt = maint_stmt.where(MaintenanceRequest.owner_id.in_(owner_ids))
     try:
-        maint_stmt = select(MaintenanceRequest).order_by(MaintenanceRequest.created_at.desc()).limit(limit)
-        if owner_ids is not None:
-            maint_stmt = maint_stmt.where(MaintenanceRequest.owner_id.in_(owner_ids))
-        requests = list((await db.execute(maint_stmt)).scalars().all())
-        for r in requests:
+        maint_result = await execute_with_transient_retry(
+            db, operation=lambda: db.execute(maint_stmt), operation_name="fetch_maintenance_requests",
+        )
+        for r in maint_result.scalars().all():
             status_val = getattr(r.request_status, "value", r.request_status)
             activities.append(
                 {
@@ -198,15 +205,16 @@ async def get_recent_activity(
                 }
             )
     except Exception as e:
-        import logging
-        logging.getLogger(__name__).error("Failed to fetch maintenance requests for activity: %s", e)
+        logger.error("Failed to fetch maintenance requests for activity: %s", e)
 
+    lease_stmt = select(Lease).order_by(Lease.created_at.desc()).limit(limit)
+    if owner_ids is not None:
+        lease_stmt = lease_stmt.where(Lease.owner_id.in_(owner_ids))
     try:
-        lease_stmt = select(Lease).order_by(Lease.created_at.desc()).limit(limit)
-        if owner_ids is not None:
-            lease_stmt = lease_stmt.where(Lease.owner_id.in_(owner_ids))
-        leases = list((await db.execute(lease_stmt)).scalars().all())
-        for lease in leases:
+        lease_result = await execute_with_transient_retry(
+            db, operation=lambda: db.execute(lease_stmt), operation_name="fetch_leases",
+        )
+        for lease in lease_result.scalars().all():
             status_val = getattr(lease.status, "value", lease.status)
             activities.append(
                 {
@@ -220,8 +228,7 @@ async def get_recent_activity(
                 }
             )
     except Exception as e:
-        import logging
-        logging.getLogger(__name__).error("Failed to fetch leases for activity: %s", e)
+        logger.error("Failed to fetch leases for activity: %s", e)
 
     activities.sort(key=lambda x: x.get("at") or "", reverse=True)
     return activities[:limit]

--- a/app/services/pm_dashboard.py
+++ b/app/services/pm_dashboard.py
@@ -156,52 +156,72 @@ async def get_recent_activity(
 
     activities: list[dict[str, Any]] = []
 
-    pay_stmt = select(RentPayment).order_by(RentPayment.paid_at.desc()).limit(limit)
-    if owner_ids is not None:
-        pay_stmt = pay_stmt.where(RentPayment.owner_id.in_(owner_ids))
-    payments = list((await db.execute(pay_stmt)).scalars().all())
-    for p in payments:
-        activities.append(
-            {
-                "type": "rent_payment",
-                "at": p.paid_at.isoformat(),
-                "property_id": p.property_id,
-                "lease_id": p.lease_id,
-                "amount": p.amount_paid,
-                "id": p.id,
-            }
-        )
+    try:
+        pay_stmt = select(RentPayment).order_by(RentPayment.paid_at.desc()).limit(limit)
+        if owner_ids is not None:
+            pay_stmt = pay_stmt.where(RentPayment.owner_id.in_(owner_ids))
+        payments = list((await db.execute(pay_stmt)).scalars().all())
+        for p in payments:
+            activities.append(
+                {
+                    "type": "rent_payment",
+                    "at": p.paid_at.isoformat(),
+                    "title": "Payment Received",
+                    "message": f"₹{p.amount_paid:,.0f} payment recorded",
+                    "property_id": p.property_id,
+                    "lease_id": p.lease_id,
+                    "amount": p.amount_paid,
+                    "id": p.id,
+                }
+            )
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).error("Failed to fetch rent payments for activity: %s", e)
 
-    maint_stmt = select(MaintenanceRequest).order_by(MaintenanceRequest.created_at.desc()).limit(limit)
-    if owner_ids is not None:
-        maint_stmt = maint_stmt.where(MaintenanceRequest.owner_id.in_(owner_ids))
-    requests = list((await db.execute(maint_stmt)).scalars().all())
-    for r in requests:
-        activities.append(
-            {
-                "type": "maintenance_request",
-                "at": r.created_at.isoformat(),
-                "property_id": r.property_id,
-                "lease_id": r.lease_id,
-                "status": getattr(r.request_status, "value", r.request_status),
-                "id": r.id,
-            }
-        )
+    try:
+        maint_stmt = select(MaintenanceRequest).order_by(MaintenanceRequest.created_at.desc()).limit(limit)
+        if owner_ids is not None:
+            maint_stmt = maint_stmt.where(MaintenanceRequest.owner_id.in_(owner_ids))
+        requests = list((await db.execute(maint_stmt)).scalars().all())
+        for r in requests:
+            status_val = getattr(r.request_status, "value", r.request_status)
+            activities.append(
+                {
+                    "type": "maintenance_request",
+                    "at": r.created_at.isoformat(),
+                    "title": r.title or "Maintenance Request",
+                    "message": f"Status: {status_val.replace('_', ' ').title()}",
+                    "property_id": r.property_id,
+                    "lease_id": r.lease_id,
+                    "status": status_val,
+                    "id": r.id,
+                }
+            )
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).error("Failed to fetch maintenance requests for activity: %s", e)
 
-    lease_stmt = select(Lease).order_by(Lease.created_at.desc()).limit(limit)
-    if owner_ids is not None:
-        lease_stmt = lease_stmt.where(Lease.owner_id.in_(owner_ids))
-    leases = list((await db.execute(lease_stmt)).scalars().all())
-    for lease in leases:
-        activities.append(
-            {
-                "type": "lease",
-                "at": lease.created_at.isoformat(),
-                "property_id": lease.property_id,
-                "lease_id": lease.id,
-                "status": getattr(lease.status, "value", lease.status),
-            }
-        )
+    try:
+        lease_stmt = select(Lease).order_by(Lease.created_at.desc()).limit(limit)
+        if owner_ids is not None:
+            lease_stmt = lease_stmt.where(Lease.owner_id.in_(owner_ids))
+        leases = list((await db.execute(lease_stmt)).scalars().all())
+        for lease in leases:
+            status_val = getattr(lease.status, "value", lease.status)
+            activities.append(
+                {
+                    "type": "lease",
+                    "at": lease.created_at.isoformat(),
+                    "title": "Lease Update",
+                    "message": f"Status: {status_val.replace('_', ' ').title()}",
+                    "property_id": lease.property_id,
+                    "lease_id": lease.id,
+                    "status": status_val,
+                }
+            )
+    except Exception as e:
+        import logging
+        logging.getLogger(__name__).error("Failed to fetch leases for activity: %s", e)
 
     activities.sort(key=lambda x: x.get("at") or "", reverse=True)
     return activities[:limit]


### PR DESCRIPTION
## Summary
- Add `title` and `message` fields to `ActivityItem` schema so the mobile app can display meaningful activity descriptions
- Wrap each activity query (rent payments, maintenance requests, leases) in `try/except` to prevent transient DB errors from crashing the entire `/pm/dashboard/activity` endpoint
- Applied missing migration for `leases.termination_date` and `leases.termination_reason` columns directly to the database

## Context
The `/pm/dashboard/activity` endpoint was returning 500 errors with SQLAlchemy tracebacks. Root cause: no error handling around individual queries meant a single failed query (e.g., transient connection issue with PgBouncer/NullPool in serverless mode) would crash the whole endpoint.

## Changes
- `app/schemas/pm_dashboard.py` — added `title: str | None` and `message: str | None` to `ActivityItem`
- `app/services/pm_dashboard.py` — each of the 3 queries now has its own `try/except`, generates `title`/`message` content, and logs failures without crashing

## Testing
- Verified all 3 queries execute successfully against the production database (all tables exist, 0 rows currently)
- Applied the `20260511000000_add_lease_termination_fields.sql` migration directly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved resilience of `/pm/dashboard/activity` with automatic rollback/retry on transient DB errors and enriched activity items with readable titles and messages for the mobile app.

- **New Features**
  - Added `title` and `message` to `ActivityItem`.
  - Auto-generate friendly titles/messages for rent payments, maintenance requests, and leases.

- **Bug Fixes**
  - Use `execute_with_transient_retry` from `app.core.db_resilience` to rollback/retry transient DB errors (fixes PendingRollbackError); endpoint returns partial results instead of failing.
  - Move logger to module scope via `get_logger` and wrap only DB execution (query construction is outside try blocks).
  - Applied the missing `leases.termination_date` and `leases.termination_reason` migration to keep the schema in sync.

<sup>Written for commit 4f7efca9f7b7305a9dd826d93ed49e56e77a21dc. Summary will update on new commits. <a href="https://cubic.dev/pr/360ghar/backend/pull/16?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Activity items now display titles and formatted messages, including humanized status information for maintenance requests and leases.

* **Bug Fixes**
  * Activity feed is now more resilient; individual query failures no longer prevent the entire activity feed from loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/360ghar/backend/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens the `/pm/dashboard/activity` endpoint by wrapping each of the three DB queries in `try/except` blocks backed by `execute_with_transient_retry`, and enriches `ActivityItem` with `title` and `message` fields for the mobile app.

- **Schema change** (`app/schemas/pm_dashboard.py`): Two optional string fields — `title` and `message` — are added to `ActivityItem`; backward-compatible since both default to `None`.
- **Service change** (`app/services/pm_dashboard.py`): Each query (rent payments, maintenance requests, leases) is now wrapped in its own `try/except` that delegates to `execute_with_transient_retry` for retrying transient errors, and logs (but does not propagate) persistent failures so the endpoint can return partial results.

<h3>Confidence Score: 4/5</h3>

The resilience wrapping is a meaningful improvement, but the session-isolation gaps between the three query blocks mean a single failed query can still cascade and silence the other two — the partial-results guarantee the PR advertises is only partially delivered.

The inter-block session state problem (no rollback in the outer except handlers) and the mixed try scope covering both fetch and loop iteration were flagged in prior review threads and remain unaddressed. Under either a non-transient error or a transient error whose retry also fails, the SQLAlchemy session is left with a pending rollback, causing the subsequent blocks to raise PendingRollbackError and log errors as well — collapsing what should be independent failure isolation. The schema additions and logger wiring are correct and present no risk.

app/services/pm_dashboard.py — the three try/except blocks need explicit rollback calls in their except handlers and the DB-execute call should be split from the for-loop into separate try scopes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/schemas/pm_dashboard.py | Adds optional `title: str | None` and `message: str | None` fields to `ActivityItem`; fully backward-compatible and correctly placed. |
| app/services/pm_dashboard.py | Wraps each activity query in `try/except` + `execute_with_transient_retry`; the resilience design has known gaps (session rollback not called in the except handlers between blocks, and the try scope covers both the DB call and loop iteration) that were flagged in prior review threads and are not yet addressed. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GET /pm/dashboard/activity] --> B[_resolve_owner_scope]
    B --> C[Build pay_stmt]
    C --> D{execute_with_transient_retry - rent payments}
    D -->|success| E[Append rent_payment items with title+message]
    D -->|transient error| F[rollback + invalidate + retry]
    F -->|retry ok| E
    F -->|retry fails| G[logger.error - session dirty]
    D -->|non-transient| G
    E --> H[Build maint_stmt]
    G --> H
    H --> I{execute_with_transient_retry - maintenance}
    I -->|success| J[Append maintenance items with title+message]
    I -->|failure| K[logger.error]
    J --> L[Build lease_stmt]
    K --> L
    L --> M{execute_with_transient_retry - leases}
    M -->|success| N[Append lease items with title+message]
    M -->|failure| O[logger.error]
    N --> P[sort by at desc, slice to limit]
    O --> P
    P --> Q[Return partial or full activity list]
```

<sub>Reviews (2): Last reviewed commit: ["fix: use execute\_with\_transient\_retry an..."](https://github.com/360ghar/backend/commit/4f7efca9f7b7305a9dd826d93ed49e56e77a21dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32622435)</sub>

<!-- /greptile_comment -->