### PR TITLE
fix: add storage RLS policies for 360ghar-storage bucket

### DIFF
--- a/supabase/migrations/20260516000000_configure_storage_rls_policies.sql
+++ b/supabase/migrations/20260516000000_configure_storage_rls_policies.sql
@@ -1,0 +1,115 @@
+-- ================================================================
+-- Configure Storage RLS for 360ghar-storage Bucket
+--
+-- Flutter uploads directly to Supabase Storage using:
+--   bucket: 360ghar-storage
+--   paths:
+--     users/{uid}/listings/{filename}  — listing photos & video tours
+--     users/{uid}/profile/{filename}   — profile photos
+--     users/{uid}/chats/{filename}     — chat photos
+--
+-- After uploading, Flutter calls createSignedUrl (requires SELECT).
+-- Backend uses service role key which bypasses RLS entirely.
+--
+-- ⚠️  Run this via the Supabase Dashboard SQL Editor
+--    (SQL migrations lack owner permissions on storage.objects).
+-- ================================================================
+
+-- ── Ensure RLS is enabled ──────────────────────────────────────
+ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
+
+-- ================================================================
+-- 1. BROAD OWN-FOLDER POLICIES (covers listings, profile, chats)
+--    Pattern: users/{auth.uid()}/*
+-- ================================================================
+
+-- ── INSERT: authenticated users can upload into their own folder ──
+DROP POLICY IF EXISTS "users_insert_own" ON storage.objects;
+CREATE POLICY "users_insert_own"
+  ON storage.objects FOR INSERT TO authenticated
+  WITH CHECK (
+      bucket_id = '360ghar-storage'
+      AND auth.uid() IS NOT NULL
+      AND name ~ ('^users/' || auth.uid()::text || '/[^/]+/[^/]+$')
+  );
+
+-- ── SELECT: authenticated users can read their own files ──
+DROP POLICY IF EXISTS "users_select_own" ON storage.objects;
+CREATE POLICY "users_select_own"
+  ON storage.objects FOR SELECT TO authenticated
+  USING (
+      bucket_id = '360ghar-storage'
+      AND auth.uid() IS NOT NULL
+      AND name ~ ('^users/' || auth.uid()::text || '/[^/]+/[^/]+$')
+  );
+
+-- ── UPDATE: authenticated users can update their own files ──
+DROP POLICY IF EXISTS "users_update_own" ON storage.objects;
+CREATE POLICY "users_update_own"
+  ON storage.objects FOR UPDATE TO authenticated
+  USING (
+      bucket_id = '360ghar-storage'
+      AND auth.uid() IS NOT NULL
+      AND name ~ ('^users/' || auth.uid()::text || '/[^/]+/[^/]+$')
+  )
+  WITH CHECK (
+      bucket_id = '360ghar-storage'
+      AND auth.uid() IS NOT NULL
+      AND name ~ ('^users/' || auth.uid()::text || '/[^/]+/[^/]+$')
+  );
+
+-- ── DELETE: authenticated users can delete their own files ──
+DROP POLICY IF EXISTS "users_delete_own" ON storage.objects;
+CREATE POLICY "users_delete_own"
+  ON storage.objects FOR DELETE TO authenticated
+  USING (
+      bucket_id = '360ghar-storage'
+      AND auth.uid() IS NOT NULL
+      AND name ~ ('^users/' || auth.uid()::text || '/[^/]+/[^/]+$')
+  );
+
+-- ================================================================
+-- 2. CROSS-USER READ: authenticated users can read listing photos
+--    (so other users see listing images when browsing).
+--    Uses signed URLs (10-year expiry) as a fallback, but this
+--    policy allows direct reads too.
+-- ================================================================
+
+DROP POLICY IF EXISTS "authenticated_read_listings" ON storage.objects;
+CREATE POLICY "authenticated_read_listings"
+  ON storage.objects FOR SELECT TO authenticated
+  USING (
+      bucket_id = '360ghar-storage'
+      AND name ~ '^users/[^/]+/listings/[^/]+$'
+  );
+
+-- ================================================================
+-- 3. PUBLIC READ: agent avatars (already documented in bucket config)
+-- ================================================================
+
+DROP POLICY IF EXISTS "public_read_agent_avatars" ON storage.objects;
+CREATE POLICY "public_read_agent_avatars"
+  ON storage.objects FOR SELECT TO anon, authenticated
+  USING (
+      bucket_id = '360ghar-storage'
+      AND name ~ '^agents/[0-9]+/avatars/[^/]+$'
+  );
+
+-- ================================================================
+-- 4. AUTHENTICATED READ: tour content
+-- ================================================================
+
+DROP POLICY IF EXISTS "authenticated_read_tours" ON storage.objects;
+CREATE POLICY "authenticated_read_tours"
+  ON storage.objects FOR SELECT TO authenticated
+  USING (
+      bucket_id = '360ghar-storage'
+      AND name ~ '^users/[^/]+/tours/[^/]+$'
+  );
+
+-- ================================================================
+-- Cleanup: drop the old narrow policies if they existed
+-- ================================================================
+
+DROP POLICY IF EXISTS "flatmates_listing_photos_insert_own" ON storage.objects;
+DROP POLICY IF EXISTS "flatmates_listing_photos_select_own" ON storage.objects;


### PR DESCRIPTION
## Problem

Flutter uploads listing/profile/chat photos directly to Supabase Storage but no RLS policies existed on `storage.objects`, causing:

```
Storage upload failed: new row violates row-level security policy
```

This blocked **all** image uploads from the mobile app (listing photos, profile photos, chat photos).

## Root Cause

- The bucket `360ghar-storage` is **private** with RLS enabled on `storage.objects`
- The original bucket config migration (`20260115000100`) noted that RLS policies must be created **manually via the Supabase Dashboard** but this was never done
- A draft migration existed but was untracked, only covered `listings/`, and was never applied

## Fix

Adds comprehensive RLS policies for the `360ghar-storage` bucket:

| Policy | Operation | Who | Path Pattern |
|--------|-----------|-----|-------------|
| `users_insert_own` | INSERT | authenticated | `users/{uid}/*` |
| `users_select_own` | SELECT | authenticated | `users/{uid}/*` |
| `users_update_own` | UPDATE | authenticated | `users/{uid}/*` |
| `users_delete_own` | DELETE | authenticated | `users/{uid}/*` |
| `authenticated_read_listings` | SELECT | authenticated | `users/*/listings/*` |
| `public_read_agent_avatars` | SELECT | anon + authenticated | `agents/*/avatars/*` |
| `authenticated_read_tours` | SELECT | authenticated | `users/*/tours/*` |

Covers all Flutter upload paths: `listings/`, `profile/`, `chats/`.

## Post-Merge Action Required

> **This migration must be run via the Supabase Dashboard SQL Editor** (standard migrations lack owner permissions on `storage.objects`).

1. Go to **Supabase Dashboard → SQL Editor**
2. Copy the contents of `supabase/migrations/20260516000000_configure_storage_rls_policies.sql`
3. Paste and click **Run**

Uploads will start working immediately after the policies are applied.

## Files Changed

- `supabase/migrations/20260516000000_configure_storage_rls_policies.sql` (new file, 115 lines)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add RLS policies for `360ghar-storage` to fix “new row violates row-level security policy” and restore listing, profile, and chat image uploads from Flutter.

- **Bug Fixes**
  - Enabled RLS on `storage.objects` and added INSERT/SELECT/UPDATE/DELETE for `users/{uid}/*`.
  - Authenticated SELECT for `users/*/listings/*` and `users/*/tours/*`; public SELECT for `agents/*/avatars/*`.
  - Covers Flutter paths: `users/{uid}/listings/*`, `users/{uid}/profile/*`, `users/{uid}/chats/*`; removed old narrow policies.

- **Migration**
  - Run `supabase/migrations/20260516000000_configure_storage_rls_policies.sql` in the Supabase Dashboard SQL Editor (needed for `storage.objects` permissions).
  - Uploads will work immediately after applying.

<sup>Written for commit 7630275bdc4940ba6ed4451dc92e4d8e531a753f. Summary will update on new commits. <a href="https://cubic.dev/pr/360ghar/backend/pull/17?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented secure file storage with granular user-based access controls
  * Enabled authenticated users to manage and share listing photos
  * Made agent profile avatars publicly visible
  * Implemented restricted access controls for tour content
  * Migrated and consolidated storage security policies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/360ghar/backend/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new SQL migration (`20260516000000_configure_storage_rls_policies.sql`) that creates seven RLS policies on `storage.objects` for the `360ghar-storage` Supabase bucket, unblocking Flutter direct uploads of listing, profile, and chat photos. It must be applied manually via the Supabase Dashboard SQL Editor rather than the standard migration pipeline.

- **Own-folder CRUD policies** grant INSERT/SELECT/UPDATE/DELETE to authenticated users for paths matching `users/{uid}/<subfolder>/<file>` (exactly one subfolder deep).
- **Cross-user SELECT policies** allow any authenticated user to read `listings/` and `tours/` paths, and allow public (anon) access to `agents/*/avatars/*`.
- **Chat photos** have no cross-user SELECT policy; recipients cannot directly read or create signed URLs for `users/{sender_uid}/chats/*` files from the Flutter client.

<h3>Confidence Score: 3/5</h3>

Safe to merge as SQL, but the missing chat cross-user SELECT policy means chat photo recipients may hit access denials if Flutter fetches those objects directly or calls createSignedUrl client-side.

The own-folder CRUD policies and cross-user listing/tour/avatar reads are well-constructed with tight regex depth. The gap is that users/*/chats/* has no SELECT policy for non-owners, leaving a real risk of silent breakage for the chat photo feature this PR is meant to fix.

supabase/migrations/20260516000000_configure_storage_rls_policies.sql — specifically the absence of a cross-user SELECT for the chats path and the 10-year signed URL expiry note.

<details open><summary><h3>Security Review</h3></summary>

- **Long-lived signed URLs (10-year expiry)**: The migration comment references signed URLs with a 10-year expiry. URLs of this duration are functionally permanent public links; leakage via logs, forwarded messages, or API responses would expose private storage objects indefinitely.
- **Chat photo visibility gap**: No SELECT policy exists for `users/*/chats/*` paths, so chat recipients cannot directly fetch or sign those objects from the client — a present access-control gap if Flutter ever calls `createSignedUrl` client-side for received chat photos.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| supabase/migrations/20260516000000_configure_storage_rls_policies.sql | Adds RLS policies for 360ghar-storage; covers INSERT/SELECT/UPDATE/DELETE for own-folder paths and cross-user reads for listings, tours, and agent avatars, but lacks a SELECT policy for chat photos, which would block recipients from reading received images if they fetch directly or create signed URLs client-side. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add storage RLS policies for 360gha..."](https://github.com/360ghar/backend/commit/7630275bdc4940ba6ed4451dc92e4d8e531a753f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32760039)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->