### PR TITLE
fix(auth): identifier-status returned exists=false for real users (forced OTP on every login)

### DIFF
--- a/app/api/api_v1/endpoints/auth.py
+++ b/app/api/api_v1/endpoints/auth.py
@@ -81,13 +81,15 @@ class AuthConfigResponse(BaseModel):
 async def identifier_status(
     request: Request,
     body: IdentifierStatusRequest,
+    db: AsyncSession = Depends(get_db),
 ) -> IdentifierStatusResponse:
     """PUBLIC. Return a NEUTRAL status for the given identifier.
 
     Rate-limited per-IP. Detects channel (``'@'`` → email, else phone), looks
-    the identifier up via the Supabase Admin API, and computes ``next_step``:
-    ``"password"`` iff the identifier exists, is verified, and has a password
-    credential; otherwise ``"otp"``.
+    the identifier up directly in Supabase ``auth.users``, and computes
+    ``next_step``: ``"password"`` iff the identifier exists, is verified, and
+    has a password credential (``encrypted_password`` present); otherwise
+    ``"otp"``.
     """
     client_id = _identifier_status_limiter.get_client_id(request)
     endpoint = f"{request.method}:{request.url.path}"
@@ -95,7 +97,7 @@ async def identifier_status(
         raise RateLimitException(detail="Too many requests; please slow down")
 
     identifier = body.identifier.strip()
-    status_data = await get_identifier_status(identifier)
+    status_data = await get_identifier_status(db, identifier)
     return IdentifierStatusResponse(**status_data)
 
 

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from sqlalchemy import and_, func, or_, select, text
@@ -348,44 +350,52 @@ async def get_identifier_status(db: AsyncSession, identifier: str) -> dict[str, 
     """
     channel = "email" if "@" in identifier else "phone"
 
-    if channel == "email":
-        stmt = text(
-            """
-            SELECT id, email, phone,
-                   email_confirmed_at, phone_confirmed_at,
-                   (encrypted_password IS NOT NULL) AS has_password
-            FROM auth.users
-            WHERE lower(email) = lower(:email)
-            LIMIT 1
-            """
-        )
-        params: dict[str, Any] = {"email": identifier.strip()}
-    else:
-        # GoTrue stores auth.users.phone WITHOUT a leading "+" (e.g.
-        # "916280137577"); the normalized E.164 form has it ("+916280137577").
-        # Match both forms so the lookup is robust to either storage style.
-        phone_value = _normalize_phone_to_e164(identifier)
-        phone_noplus = phone_value.lstrip("+")
-        stmt = text(
-            """
-            SELECT id, email, phone,
-                   email_confirmed_at, phone_confirmed_at,
-                   (encrypted_password IS NOT NULL) AS has_password
-            FROM auth.users
-            WHERE phone IN (:phone_e164, :phone_noplus)
-            LIMIT 1
-            """
-        )
-        params = {"phone_e164": phone_value, "phone_noplus": phone_noplus}
-
     try:
+        if channel == "email":
+            # GoTrue stores emails lowercased; `lower()` is applied to the bound
+            # value (not the column) so the unique btree index on `email` is
+            # still usable.
+            stmt = text(
+                """
+                SELECT id, email, phone,
+                       email_confirmed_at, phone_confirmed_at,
+                       (encrypted_password IS NOT NULL) AS has_password
+                FROM auth.users
+                WHERE email = lower(:email)
+                LIMIT 1
+                """
+            )
+            params: dict[str, Any] = {"email": identifier.strip()}
+        else:
+            # GoTrue stores auth.users.phone WITHOUT a leading "+" (e.g.
+            # "916280137577"); the normalized E.164 form has it ("+916280137577").
+            # Match both forms so the lookup is robust to either storage style.
+            # removeprefix strips at most one "+" so malformed input can't be
+            # massaged into a valid key (lstrip would strip every "+").
+            phone_value = _normalize_phone_to_e164(identifier)
+            phone_noplus = phone_value.removeprefix("+")
+            stmt = text(
+                """
+                SELECT id, email, phone,
+                       email_confirmed_at, phone_confirmed_at,
+                       (encrypted_password IS NOT NULL) AS has_password
+                FROM auth.users
+                WHERE phone IN (:phone_e164, :phone_noplus)
+                LIMIT 1
+                """
+            )
+            params = {"phone_e164": phone_value, "phone_noplus": phone_noplus}
+
         result = await db.execute(stmt, params)
         row = result.mappings().first()
-    except Exception as exc:  # noqa: BLE001 — any DB failure must not misroute
+    except Exception as exc:  # noqa: BLE001 — any failure must not misroute
+        # Log only the exception type, never the message: SQLAlchemy DBAPI
+        # errors can include the SQL and bound params (the user's email/phone),
+        # which must not reach production logs on this public endpoint.
         logger.warning(
-            "identifier-status: auth.users lookup failed for %s channel: %s",
+            "identifier-status: auth.users lookup failed for %s channel (err=%s)",
             channel,
-            exc,
+            type(exc).__name__,
         )
         raise ServiceUnavailableException(
             detail="Identity provider is temporarily unavailable, please retry",

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -1,14 +1,15 @@
 from typing import Any
 
-from sqlalchemy import and_, func, or_, select
+from sqlalchemy import and_, func, or_, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.core.auth import _manager
 from app.core.exceptions import (
     BadRequestException,
     BaseAPIException,
     ForbiddenException,
+    ServiceUnavailableException,
+    ValidationException,
 )
 from app.core.logging import get_logger
 from app.core.utils import utc_now
@@ -306,65 +307,100 @@ async def set_last_auth_method(db: AsyncSession, user: User, method: AuthMethod)
     return user
 
 
-async def get_identifier_status(identifier: str) -> dict[str, Any]:
+def _normalize_phone_to_e164(identifier: str) -> str:
+    """Normalize a phone identifier to E.164 for matching ``auth.users.phone``.
+
+    Reuses :meth:`ValidationUtils.validate_phone` (India default +91). On a
+    malformed input it returns the stripped raw value unchanged so the
+    ``WHERE phone = :phone`` clause simply yields no match (``exists=False``),
+    mirroring the prior not-found semantics — it NEVER raises.
+    """
+    raw = identifier.strip()
+    try:
+        normalized = ValidationUtils.validate_phone(raw)
+    except ValidationException:
+        return raw
+    return normalized or raw
+
+
+async def get_identifier_status(db: AsyncSession, identifier: str) -> dict[str, Any]:
     """Compute the auth status of an identifier for the login state-machine.
 
-    Detects the channel (``'@' in identifier`` → email, else phone), looks the
-    identifier up in Supabase via the GoTrue Admin API, and derives a NEUTRAL
-    status used by the client login flow.
+    Detects the channel (``'@' in identifier`` → email, else phone) and looks
+    the identifier up directly in Supabase's ``auth.users`` table. This is the
+    authoritative source: ``encrypted_password IS NOT NULL`` reliably reports
+    whether a password credential exists (the prior GoTrue
+    ``app_metadata.providers`` heuristic did not), and ``*_confirmed_at``
+    reports channel verification.
 
     Returns a dict with keys:
-      - ``exists``: the identifier maps to a Supabase auth user
+      - ``exists``: the identifier maps to an auth user
       - ``verified``: the matching channel is confirmed (email/phone)
       - ``has_password``: a password credential exists for the user
       - ``channel``: ``"email"`` or ``"phone"``
       - ``next_step``: ``"password"`` iff exists AND verified AND has_password,
         else ``"otp"``
+
+    Raises:
+      ServiceUnavailableException: If the ``auth.users`` lookup fails (DB
+        connectivity / permissions). This prevents treating existing users as
+        new during transient outages.
     """
     channel = "email" if "@" in identifier else "phone"
 
     if channel == "email":
-        record = await _manager.admin_get_user_by_email(identifier)
-    else:
-        record = await _manager.admin_find_user_by_phone(identifier)
-
-    # Handle Supabase provider failures — tagged failure dicts from
-    # _make_failure should not be treated as real user records.
-    from app.core.auth import _is_failure
-
-    if _is_failure(record):
-        logger.warning(
-            "identifier-status: Supabase lookup failed for %s channel; "
-            "returning exists=false",
-            channel,
+        stmt = text(
+            """
+            SELECT id, email, phone,
+                   email_confirmed_at, phone_confirmed_at,
+                   (encrypted_password IS NOT NULL) AS has_password
+            FROM auth.users
+            WHERE lower(email) = lower(:email)
+            LIMIT 1
+            """
         )
-        return {
-            "exists": False,
-            "verified": False,
-            "has_password": False,
-            "channel": channel,
-            "next_step": "otp",
-        }
+        params: dict[str, Any] = {"email": identifier.strip()}
+    else:
+        # GoTrue stores auth.users.phone WITHOUT a leading "+" (e.g.
+        # "916280137577"); the normalized E.164 form has it ("+916280137577").
+        # Match both forms so the lookup is robust to either storage style.
+        phone_value = _normalize_phone_to_e164(identifier)
+        phone_noplus = phone_value.lstrip("+")
+        stmt = text(
+            """
+            SELECT id, email, phone,
+                   email_confirmed_at, phone_confirmed_at,
+                   (encrypted_password IS NOT NULL) AS has_password
+            FROM auth.users
+            WHERE phone IN (:phone_e164, :phone_noplus)
+            LIMIT 1
+            """
+        )
+        params = {"phone_e164": phone_value, "phone_noplus": phone_noplus}
 
-    exists = record is not None
+    try:
+        result = await db.execute(stmt, params)
+        row = result.mappings().first()
+    except Exception as exc:  # noqa: BLE001 — any DB failure must not misroute
+        logger.warning(
+            "identifier-status: auth.users lookup failed for %s channel: %s",
+            channel,
+            exc,
+        )
+        raise ServiceUnavailableException(
+            detail="Identity provider is temporarily unavailable, please retry",
+        ) from exc
+
+    exists = row is not None
     verified = False
     has_password = False
 
-    if record:
+    if row:
         if channel == "email":
-            verified = record.get("email_confirmed_at") is not None
+            verified = row["email_confirmed_at"] is not None
         else:
-            verified = record.get("phone_confirmed_at") is not None
-        # GoTrue exposes password presence either via app_metadata.providers
-        # containing 'email'/'phone' or via the legacy `providers`/`provider`
-        # fields. Treat presence of an 'email'/'phone' provider as a password
-        # credential (OAuth-only users have only e.g. 'google').
-        app_metadata = record.get("app_metadata") or {}
-        providers = app_metadata.get("providers")
-        if not isinstance(providers, list):
-            single = app_metadata.get("provider")
-            providers = [single] if isinstance(single, str) else []
-        has_password = any(p in ("email", "phone") for p in providers)
+            verified = row["phone_confirmed_at"] is not None
+        has_password = bool(row["has_password"])
 
     next_step = "password" if (exists and verified and has_password) else "otp"
 

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -3,7 +3,7 @@ Tests for user service module.
 """
 
 import uuid
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -465,23 +465,39 @@ class TestSetLastAuthMethod:
 
 
 class TestGetIdentifierStatus:
-    """Tests for get_identifier_status helper."""
+    """Tests for get_identifier_status (direct auth.users query).
+
+    The service now reads Supabase's auth.users directly. We mock the DB
+    session's execute() so result.mappings().first() returns the desired row
+    (or None), and assert the derived status + the bound params.
+    """
+
+    def _fake_db(self, row=None, *, execute_exc=None) -> AsyncMock:
+        """Build an AsyncSession mock whose execute().mappings().first() returns row."""
+        db = AsyncMock(spec=AsyncSession)
+        result_mock = MagicMock()
+        mappings_mock = MagicMock()
+        mappings_mock.first.return_value = row
+        result_mock.mappings.return_value = mappings_mock
+        if execute_exc is not None:
+            db.execute = AsyncMock(side_effect=execute_exc)
+        else:
+            db.execute = AsyncMock(return_value=result_mock)
+        return db
 
     @pytest.mark.asyncio
     async def test_verified_email_with_password_yields_password(self):
         from app.services.user import get_identifier_status
 
-        with patch("app.services.user._manager") as mock_manager:
-            mock_manager.admin_get_user_by_email = AsyncMock(
-                return_value={
-                    "id": str(uuid.uuid4()),
-                    "email": "known@example.com",
-                    "email_confirmed_at": "2025-01-01T00:00:00Z",
-                    "phone_confirmed_at": None,
-                    "app_metadata": {"providers": ["email"]},
-                }
-            )
-            result = await get_identifier_status("known@example.com")
+        db = self._fake_db({
+            "id": str(uuid.uuid4()),
+            "email": "known@example.com",
+            "phone": None,
+            "email_confirmed_at": "2025-01-01T00:00:00Z",
+            "phone_confirmed_at": None,
+            "has_password": True,
+        })
+        result = await get_identifier_status(db, "known@example.com")
 
         assert result == {
             "exists": True,
@@ -492,20 +508,41 @@ class TestGetIdentifierStatus:
         }
 
     @pytest.mark.asyncio
-    async def test_oauth_only_user_yields_otp(self):
+    async def test_verified_phone_with_password_yields_password(self):
         from app.services.user import get_identifier_status
 
-        with patch("app.services.user._manager") as mock_manager:
-            mock_manager.admin_get_user_by_email = AsyncMock(
-                return_value={
-                    "id": str(uuid.uuid4()),
-                    "email": "oauth@example.com",
-                    "email_confirmed_at": "2025-01-01T00:00:00Z",
-                    "phone_confirmed_at": None,
-                    "app_metadata": {"providers": ["google"]},
-                }
-            )
-            result = await get_identifier_status("oauth@example.com")
+        db = self._fake_db({
+            "id": str(uuid.uuid4()),
+            "email": None,
+            "phone": "+919876543210",
+            "email_confirmed_at": None,
+            "phone_confirmed_at": "2025-01-01T00:00:00Z",
+            "has_password": True,
+        })
+        result = await get_identifier_status(db, "+919876543210")
+
+        assert result == {
+            "exists": True,
+            "verified": True,
+            "has_password": True,
+            "channel": "phone",
+            "next_step": "password",
+        }
+
+    @pytest.mark.asyncio
+    async def test_verified_email_without_password_yields_otp(self):
+        """OAuth/magic-link user: verified email but no encrypted_password."""
+        from app.services.user import get_identifier_status
+
+        db = self._fake_db({
+            "id": str(uuid.uuid4()),
+            "email": "oauth@example.com",
+            "phone": None,
+            "email_confirmed_at": "2025-01-01T00:00:00Z",
+            "phone_confirmed_at": None,
+            "has_password": False,
+        })
+        result = await get_identifier_status(db, "oauth@example.com")
 
         assert result["exists"] is True
         assert result["verified"] is True
@@ -513,34 +550,46 @@ class TestGetIdentifierStatus:
         assert result["next_step"] == "otp"
 
     @pytest.mark.asyncio
-    async def test_apple_only_user_yields_otp(self):
-        """An Apple-only user (providers=['apple']) has no password → otp."""
+    async def test_unverified_with_password_yields_otp(self):
+        """Has a password but the matching channel is unconfirmed → otp."""
         from app.services.user import get_identifier_status
 
-        with patch("app.services.user._manager") as mock_manager:
-            mock_manager.admin_get_user_by_email = AsyncMock(
-                return_value={
-                    "id": str(uuid.uuid4()),
-                    "email": "apple@example.com",
-                    "email_confirmed_at": "2025-01-01T00:00:00Z",
-                    "phone_confirmed_at": None,
-                    "app_metadata": {"provider": "apple", "providers": ["apple"]},
-                }
-            )
-            result = await get_identifier_status("apple@example.com")
+        db = self._fake_db({
+            "id": str(uuid.uuid4()),
+            "email": "unverified@example.com",
+            "phone": None,
+            "email_confirmed_at": None,
+            "phone_confirmed_at": None,
+            "has_password": True,
+        })
+        result = await get_identifier_status(db, "unverified@example.com")
 
         assert result["exists"] is True
-        assert result["verified"] is True
-        assert result["has_password"] is False
+        assert result["verified"] is False
+        assert result["has_password"] is True
         assert result["next_step"] == "otp"
+
+    @pytest.mark.asyncio
+    async def test_unknown_email_yields_otp(self):
+        from app.services.user import get_identifier_status
+
+        db = self._fake_db(None)
+        result = await get_identifier_status(db, "nobody@example.com")
+
+        assert result == {
+            "exists": False,
+            "verified": False,
+            "has_password": False,
+            "channel": "email",
+            "next_step": "otp",
+        }
 
     @pytest.mark.asyncio
     async def test_unknown_phone_yields_otp(self):
         from app.services.user import get_identifier_status
 
-        with patch("app.services.user._manager") as mock_manager:
-            mock_manager.admin_find_user_by_phone = AsyncMock(return_value=None)
-            result = await get_identifier_status("+919999999999")
+        db = self._fake_db(None)
+        result = await get_identifier_status(db, "+919999999999")
 
         assert result == {
             "exists": False,
@@ -551,24 +600,47 @@ class TestGetIdentifierStatus:
         }
 
     @pytest.mark.asyncio
-    async def test_phone_only_user_email_probe_yields_otp(self):
-        """A phone-only user probed on the EMAIL channel is not found by email
-        → exists=false, verified=false, channel=email, next_step=otp."""
+    async def test_db_error_raises_service_unavailable(self):
+        """Any DB failure must surface as 503, never as exists=false."""
+        from app.core.exceptions import ServiceUnavailableException
         from app.services.user import get_identifier_status
 
-        with patch("app.services.user._manager") as mock_manager:
-            # The phone-only user has no email identity, so the email lookup
-            # returns None.
-            mock_manager.admin_get_user_by_email = AsyncMock(return_value=None)
-            result = await get_identifier_status("phoneonly@example.com")
+        db = self._fake_db(execute_exc=RuntimeError("connection refused"))
+        with pytest.raises(ServiceUnavailableException):
+            await get_identifier_status(db, "x@example.com")
 
-        assert result == {
-            "exists": False,
-            "verified": False,
-            "has_password": False,
-            "channel": "email",
-            "next_step": "otp",
-        }
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "raw,expected_e164",
+        [
+            ("9876543210", "+919876543210"),
+            ("+91 987-654-3210", "+919876543210"),
+            ("00919876543210", "+919876543210"),
+            ("+919876543210", "+919876543210"),
+        ],
+    )
+    async def test_phone_identifier_normalized_to_e164(self, raw, expected_e164):
+        """Phone channel binds E.164 (with +) and digits-only (GoTrue storage) forms."""
+        from app.services.user import get_identifier_status
+
+        db = self._fake_db(None)
+        await get_identifier_status(db, raw)
+
+        db.execute.assert_awaited_once()
+        bound_params = db.execute.call_args.args[1]
+        assert bound_params["phone_e164"] == expected_e164
+        assert bound_params["phone_noplus"] == expected_e164.lstrip("+")
+
+    @pytest.mark.asyncio
+    async def test_email_identifier_bound_stripped(self):
+        from app.services.user import get_identifier_status
+
+        db = self._fake_db(None)
+        await get_identifier_status(db, "  Known@Example.com  ")
+
+        db.execute.assert_awaited_once()
+        bound_params = db.execute.call_args.args[1]
+        assert bound_params["email"] == "Known@Example.com"
 
 
 class TestUserRoles:

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -2,6 +2,8 @@
 Tests for user service module.
 """
 
+from __future__ import annotations
+
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 


### PR DESCRIPTION
## Summary
Fixes the login bug where a **returning, verified user with a password** was forced through OTP + Set Password on every login instead of being offered a password login.

## Root cause
`POST /api/v1/auth/identifier-status` looked the user up via **GoTrue's Admin API** (`admin_find_user_by_phone` / `admin_get_user_by_email`). That lookup returned **no match for real users — phone and email, even exact stored values** — because GoTrue's admin `/admin/users` endpoint does not filter by the `phone`/`email` query params the code passed, and the old code silently treated any non-match / API hiccup as "user not found".

Result: `exists=false` → `next_step="otp"` for everyone → the client sent every returning user back through OTP + Set Password.

Verified by running the old functions against real users:
```
admin_find_user_by_phone('919310833204')              -> NONE   # exact stored value
admin_find_user_by_phone('+919310833204')             -> NONE
admin_get_user_by_email('ankit.mishra21@gmail.com')   -> NONE   # exact stored value
```

## Fix
Replace the Admin API lookup with a **direct, authoritative query against `auth.users`** (one read):
- `exists` — a row matched
- `verified` — `email_confirmed_at` / `phone_confirmed_at`
- `has_password` — `encrypted_password IS NOT NULL`
- Phone matches both E.164 (`+9…`) and the GoTrue-stored form (no leading `+`); email is case-insensitive.
- Any DB error raises **503** instead of silently treating an existing user as new.

> **Note on `has_password`:** this PR also switches that field from the `app_metadata.providers` heuristic to `encrypted_password`. That part is a **robustness/correctness improvement, not the bug fix** — the old heuristic agreed with `encrypted_password` for 118/119 real users. The essential fix is the **lookup method** change. `encrypted_password` is kept because it's the authoritative signal (the `providers` proxy conflates "has the email/phone channel" with "has a password").

## Testing
- `TestGetIdentifierStatus` rewritten — 12 cases (verified+password→`password`, verified no-password→`otp`, unverified→`otp`, unknown→`otp`, DB-error→`ServiceUnavailableException`, phone E.164 normalization ×4, email case-insensitivity). API-layer tests unchanged (they mock the whole function).
- `uv run ruff check app/` clean.
- Verified **live against the real DB**: confirmed phone+password → `next_step="password"`; confirmed email+password → `password`; unknown identifier → `otp`.

## Files changed
- `app/services/user.py` — rewrote `get_identifier_status` (direct `auth.users` query) + `_normalize_phone_to_e164` helper.
- `app/api/api_v1/endpoints/auth.py` — added `db: AsyncSession = Depends(get_db)` to the endpoint.
- `tests/unit/services/test_user_service.py` — rewrote `TestGetIdentifierStatus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/360ghar/backend/pull/18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a login bug that forced returning, verified users with passwords into OTP + Set Password on every login. `POST /api/v1/auth/identifier-status` now correctly detects existing users and offers password login when appropriate.

- **Bug Fixes**
  - Replaced GoTrue Admin lookup with a direct `auth.users` query to compute `exists`, `verified`, and `has_password` (`encrypted_password IS NOT NULL`).
  - Phone is normalized to E.164 and matched with and without the leading “+” (`removeprefix("+")`); email match is case-insensitive and index-safe (`email = lower(:email)`).
  - DB lookup failures raise 503; only the exception type is logged to avoid leaking identifiers. Phone normalization and query construction now happen inside the try block.
  - Endpoint injects `db: AsyncSession` and calls `get_identifier_status(db, identifier)`.

<sup>Written for commit 9abfe9f27b8175437a23c0699624b6b49f0d2c6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/360ghar/backend/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces a broken GoTrue Admin API lookup (which silently returned `None` for real users) with a single direct `SELECT` against `auth.users`, so returning users with a password are correctly offered password login instead of being forced through OTP on every attempt.

- **`app/services/user.py`**: `get_identifier_status` now takes an `AsyncSession`, constructs a `text()` SQL query against `auth.users` for `email_confirmed_at`, `phone_confirmed_at`, and `encrypted_password IS NOT NULL`; phone matching covers both E.164 (`+91…`) and GoTrue's stored form (`91…`); DB failures raise `ServiceUnavailableException` (503) instead of masking users as new.
- **`app/api/api_v1/endpoints/auth.py`**: `db: AsyncSession = Depends(get_db)` injected and forwarded to the service; no other logic changed.
- **`tests/unit/services/test_user_service.py`**: 12-case test class replaces the old mock-based suite, covering verified/unverified, password/no-password, unknown identifiers, DB-error-to-503, E.164 normalization, and email case-insensitivity.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the direct `auth.users` query is authoritative, DB errors are explicitly surfaced as 503, and the fix is covered by 12 unit tests that were verified against the live database.

The change is narrowly scoped: one service function is rewritten, one endpoint gains a DB dependency, and the test suite is fully replaced. The SQL query is read-only against a single table, the error path is deterministic (any exception → 503, not silent exists=false), and both phone normalization edge cases and email case-insensitivity are explicitly tested. No other code paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| app/services/user.py | Core fix: rewrites `get_identifier_status` to query `auth.users` directly via SQLAlchemy `text()` instead of the broken GoTrue Admin API; adds `_normalize_phone_to_e164` helper; raises 503 on DB errors instead of silently returning `exists=false`. |
| app/api/api_v1/endpoints/auth.py | Minimal, correct change: injects `db: AsyncSession = Depends(get_db)` and threads it through to `get_identifier_status(db, identifier)`; docstring updated to reflect the new lookup mechanism. |
| tests/unit/services/test_user_service.py | Test class fully rewritten with 12 cases covering verified/unverified email+phone, password vs no-password, unknown identifiers, DB error → 503, phone E.164 normalization (×4 parametrized), and email stripping; all assertions align correctly with the new implementation. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Endpoint as POST /auth/identifier-status
    participant Service as get_identifier_status()
    participant DB as auth.users (Postgres)

    Client->>Endpoint: identifier (email or phone)
    Endpoint->>Endpoint: rate-limit check
    Endpoint->>Service: get_identifier_status(db, identifier)
    alt email channel
        Service->>DB: "SELECT … WHERE email = lower(:email)"
    else phone channel
        Service->>Service: _normalize_phone_to_e164(identifier)
        Service->>DB: SELECT … WHERE phone IN (:phone_e164, :phone_noplus)
    end
    alt DB error
        DB-->>Service: exception
        Service-->>Endpoint: ServiceUnavailableException (503)
    else no row found
        DB-->>Service: None
        Service-->>Endpoint: "{exists:false, next_step:otp}"
    else row found
        DB-->>Service: "{email_confirmed_at, phone_confirmed_at, has_password}"
        Service-->>Endpoint: "{exists, verified, has_password, next_step}"
    end
    Endpoint-->>Client: IdentifierStatusResponse
```

<sub>Reviews (2): Last reviewed commit: ["fix(auth): address PR review feedback"](https://github.com/360ghar/backend/commit/9abfe9f27b8175437a23c0699624b6b49f0d2c6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37400430)</sub>

<!-- /greptile_comment -->