### PR TITLE
fix: run expired flatmate listing pause as fire-and-forget background task

### DIFF
--- a/app/api/api_v1/endpoints/properties.py
+++ b/app/api/api_v1/endpoints/properties.py
@@ -24,7 +24,7 @@ from app.schemas.property import (
     UnifiedPropertyFilter,
 )
 from app.schemas.user import User as UserSchema
-from app.services.flatmates import pause_expired_flatmate_listings
+from app.services.flatmates import maintain_expired_flatmate_listings
 from app.services.property import (
     create_property,
     delete_property,
@@ -296,7 +296,7 @@ async def get_properties_list(
     )
 
     try:
-        await pause_expired_flatmate_listings(db)
+        maintain_expired_flatmate_listings()
         rows, next_payload, total = await get_unified_properties_optimized(
             db, filters, user_id, cursor_payload, page.limit,
             with_total=page.include_total,
@@ -355,7 +355,7 @@ async def semantic_property_search(
 
     try:
         cursor_payload = page.decoded()
-        await pause_expired_flatmate_listings(db)
+        maintain_expired_flatmate_listings()
         rows, next_payload, total = await get_unified_properties_optimized(
             db, filters, user_id, cursor_payload, page.limit,
             with_total=page.include_total,
@@ -395,7 +395,7 @@ async def get_recommendations(
     user_id = current_user.id if current_user else None
     try:
         cursor_payload = page.decoded()
-        await pause_expired_flatmate_listings(db)
+        maintain_expired_flatmate_listings()
         rows, next_payload, total = await get_property_recommendations(
             db, user_id, cursor_payload, page.limit,
             with_total=page.include_total,

--- a/app/services/flatmates/__init__.py
+++ b/app/services/flatmates/__init__.py
@@ -34,6 +34,7 @@ from app.services.flatmates.moderation import (
     create_report,
     delete_block,
     list_blocks,
+    maintain_expired_flatmate_listings,
     pause_expired_flatmate_listings,
     prescreen_flatmate_listing,
 )
@@ -90,6 +91,7 @@ __all__ = [
     "apply_listing_prescreen_metadata",
     "apply_report_auto_pause",
     "pause_expired_flatmate_listings",
+    "maintain_expired_flatmate_listings",
     "prescreen_flatmate_listing",
     # visits
     "update_visit_status",

--- a/app/services/flatmates/moderation.py
+++ b/app/services/flatmates/moderation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import re
 from datetime import datetime, time, timezone
 from time import monotonic
@@ -11,6 +12,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.database import get_bg_session_factory
 from app.core.exceptions import BadRequestException, PropertyNotFoundException
 from app.core.logging import get_logger
 from app.models.enums import (
@@ -556,35 +558,35 @@ def maintain_expired_flatmate_listings(
         return
     _last_expired_maintenance_epoch = monotonic()
 
-    import asyncio
-
     asyncio.create_task(_run_expired_maintenance_with_timeout())
 
 
 async def _run_expired_maintenance_with_timeout() -> None:
     """Execute the pause logic in an isolated session with a hard timeout."""
-    import asyncio
-
-    from app.core.database import get_bg_session_factory
-
     try:
         factory = get_bg_session_factory()
         async with factory() as bg_db:
             try:
-                async with asyncio.timeout(_EXPIRED_MAINTENANCE_TIMEOUT_S):
+                # Use wait_for (not asyncio.timeout) for Python 3.10 compatibility.
+                async def _pause_and_commit() -> int:
                     paused = await pause_expired_flatmate_listings(bg_db)
                     await bg_db.commit()
+                    return paused
+
+                paused = await asyncio.wait_for(
+                    _pause_and_commit(), timeout=_EXPIRED_MAINTENANCE_TIMEOUT_S,
+                )
                 if paused:
                     logger.info("Paused %d expired flatmate listings", paused)
-            except TimeoutError:
+            except asyncio.TimeoutError:
                 await bg_db.rollback()
                 logger.warning(
                     "Expired-listing maintenance timed out after %ss; skipped",
                     _EXPIRED_MAINTENANCE_TIMEOUT_S,
                 )
-            except Exception:
+            except Exception as inner_exc:
                 await bg_db.rollback()
-                raise
+                raise inner_exc from inner_exc
     except Exception as exc:  # noqa: BLE001
         logger.warning("Best-effort expired-listing maintenance failed; skipped: %s", exc)
 

--- a/app/services/flatmates/moderation.py
+++ b/app/services/flatmates/moderation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from datetime import datetime, time, timezone
+from time import monotonic
 from typing import Any
 
 from sqlalchemy import func, or_, select
@@ -11,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.core.exceptions import BadRequestException, PropertyNotFoundException
+from app.core.logging import get_logger
 from app.models.enums import (
     PG_FLATMATE_TYPES,
     ConversationStatus,
@@ -30,6 +32,8 @@ MIN_REVIEW_PHOTO_COUNT = 2
 SUSPICIOUS_RENT_CEILING = 1_000_000
 REPORT_AUTO_PAUSE_THRESHOLD = 3
 EXPIRED_MOVE_IN_PAUSE_REASON = "expired_move_in_date"
+
+logger = get_logger(__name__)
 
 _SPAM_PATTERNS: tuple[tuple[str, str, str], ...] = (
     ("adult_content", "high", r"\b(escort|call\s*girl|xxx|porn|nude|sexual\s+service)\b"),
@@ -528,6 +532,61 @@ async def pause_expired_flatmate_listings(
         else:
             break
     return paused_count
+
+
+_last_expired_maintenance_epoch: float = 0.0
+_EXPIRED_MAINTENANCE_MIN_INTERVAL_S: float = 300.0
+_EXPIRED_MAINTENANCE_TIMEOUT_S: float = 15.0
+
+
+def maintain_expired_flatmate_listings(
+    *,
+    min_interval_s: float = _EXPIRED_MAINTENANCE_MIN_INTERVAL_S,
+) -> None:
+    """Best-effort, throttled, fire-and-forget maintenance of expired listings.
+
+    Schedules the pause work as a detached background task with a hard timeout
+    so the caller's response is **never** blocked, even if the DB is under lock
+    contention. Runs at most once per ``min_interval_s`` per process. Pausing
+    expired listings is a non-critical optimization — all errors are logged and
+    swallowed. Safe to call on every read request.
+    """
+    global _last_expired_maintenance_epoch
+    if monotonic() - _last_expired_maintenance_epoch < min_interval_s:
+        return
+    _last_expired_maintenance_epoch = monotonic()
+
+    import asyncio
+
+    asyncio.create_task(_run_expired_maintenance_with_timeout())
+
+
+async def _run_expired_maintenance_with_timeout() -> None:
+    """Execute the pause logic in an isolated session with a hard timeout."""
+    import asyncio
+
+    from app.core.database import get_bg_session_factory
+
+    try:
+        factory = get_bg_session_factory()
+        async with factory() as bg_db:
+            try:
+                async with asyncio.timeout(_EXPIRED_MAINTENANCE_TIMEOUT_S):
+                    paused = await pause_expired_flatmate_listings(bg_db)
+                    await bg_db.commit()
+                if paused:
+                    logger.info("Paused %d expired flatmate listings", paused)
+            except TimeoutError:
+                await bg_db.rollback()
+                logger.warning(
+                    "Expired-listing maintenance timed out after %ss; skipped",
+                    _EXPIRED_MAINTENANCE_TIMEOUT_S,
+                )
+            except Exception:
+                await bg_db.rollback()
+                raise
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Best-effort expired-listing maintenance failed; skipped: %s", exc)
 
 
 async def create_report(db: AsyncSession, user_id: int, payload: ReportCreate) -> UserReport:


### PR DESCRIPTION
## Summary

Replaces the synchronous `await pause_expired_flatmate_listings(db)` call on the hot path of property list, semantic search, and recommendations endpoints with a throttled, fire-and-forget `maintain_expired_flatmate_listings()` wrapper.

## Problem

Every property search/recommendation request was blocking on the expired-listing pause query. Under DB lock contention this added noticeable latency to the user-facing response.

## Solution

The new `maintain_expired_flatmate_listings()` function:

- **Throttled**: runs at most once per 5 minutes per process (monotonic clock)
- **Fire-and-forget**: uses `asyncio.create_task` — never blocks the caller
- **Isolated session**: runs against a background DB session, not the request session
- **Hard timeout**: 15s timeout prevents runaway tasks
- **Best-effort**: all errors are logged and swallowed

## Changes

- `app/services/flatmates/moderation.py` — Add wrapper + helper
- `app/services/flatmates/__init__.py` — Export new function
- `app/api/api_v1/endpoints/properties.py` — Replace await call in 3 endpoints

## Testing

- ruff check passes
- No merge conflicts with origin/main
- Full test suite will validate in CI

## Risk

Low. Original pause logic unchanged. Wrapper only changes when/how it runs.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/360ghar/360ghar-backend/pull/24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the expired flatmate listing pause off the hot path by running it as a throttled, fire-and-forget background task. This removes latency spikes on property list, semantic search, and recommendations under DB contention.

- **Bug Fixes**
  - Replaced the synchronous pause with a background task that never blocks responses.
  - Throttled to run at most once every 5 minutes per process.
  - Uses an isolated background DB session with a 15s hard timeout via `asyncio.wait_for`; errors are logged and swallowed.
  - Updated the three property endpoints to call the new maintenance wrapper; moved imports to module scope and fixed exception chaining for Python 3.10 compatibility.

<sup>Written for commit 2c7348f2dc1e7454c63d7e93bb83d5b260d4aa85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/360ghar/360ghar-backend/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expired flatmate listings are now maintained automatically in the background during property searches and recommendations.
  * This maintenance is now throttled to avoid repeated work during frequent requests.

* **Bug Fixes**
  * Improved reliability of expired listing updates, with better handling for timeouts and failures so requests are less likely to be affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->