### PR TITLE
Removed hardcoded 'mock_admin_token' authentication bypass in auth.py

### DIFF
--- a/app/api/api_v1/endpoints/public.py
+++ b/app/api/api_v1/endpoints/public.py
@@ -5,6 +5,7 @@ This module provides unauthenticated endpoints for viewing published tours.
 These endpoints are used by the public viewer and embed page.
 """
 import time
+import uuid as _uuid
 from collections import defaultdict
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Request, status
@@ -128,6 +129,17 @@ async def get_public_tour(
     Returns the complete tour structure including scenes and hotspots,
     ordered by scene order_index.
     """
+    # Validate UUID format before hitting the DB.
+    # PostgreSQL will throw DataError (→ 500) if an invalid string is passed
+    # to a UUID column. Return 404 early to keep this side-effect-free.
+    try:
+        _uuid.UUID(tour_id)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tour not found",
+        )
+
     # Query tour with scenes and hotspots
     query = select(Tour).where(
         and_(

--- a/app/api/api_v1/endpoints/public.py
+++ b/app/api/api_v1/endpoints/public.py
@@ -317,9 +317,7 @@ async def track_tour_event(
         "heatmap",
         "session_start",
         "session_end",
-        "session_duration",
-        "like",
-        "unlike",
+        "session_duration",        
     }
     if event_type not in allowed_events:
         raise HTTPException(

--- a/app/api/api_v1/endpoints/public.py
+++ b/app/api/api_v1/endpoints/public.py
@@ -138,7 +138,7 @@ async def get_public_tour(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Tour not found",
-        )
+        ) from None
 
     # Query tour with scenes and hotspots
     query = select(Tour).where(
@@ -317,7 +317,7 @@ async def track_tour_event(
         "heatmap",
         "session_start",
         "session_end",
-        "session_duration",        
+        "session_duration",
     }
     if event_type not in allowed_events:
         raise HTTPException(

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -257,6 +257,18 @@ class SupabaseClientManager:
         on an invalid/expired token, or a tagged failure dict
         (:func:`_make_failure`) when the Supabase host is unreachable.
         """
+        if token == "mock_admin_token":
+            return {
+                "id": "33b56061-b629-49de-9a55-4638451978f9",
+                "email": "test.user@360ghar.com",
+                "user_metadata": {"email": "test.user@360ghar.com", "email_verified": True},
+                "app_metadata": {"provider": "email", "providers": ["email"]},
+                "phone": "+919999999999",
+                "email_verified": True,
+                "phone_verified": False,
+                "email_confirmed_at": "2026-06-18T19:35:57",
+                "phone_confirmed_at": None,
+            }
         # ── Fast path: local JWT verification ───────────────────────────────
         try:
             claims = await verify_jwt_locally(token)

--- a/app/core/auth.py
+++ b/app/core/auth.py
@@ -253,22 +253,10 @@ class SupabaseClientManager:
 
         Tries local JWKS-based verification first (signature + iss/aud/exp).
         Falls back to Supabase Auth ``GET /auth/v1/user`` introspection when
-        the JWKS is unavailable.  Returns the user dict on success, ``None``
-        on an invalid/expired token, or a tagged failure dict
-        (:func:`_make_failure`) when the Supabase host is unreachable.
+        the JWKS is unavailable. Returns the user dict on success, ``None``
+        on an invalid/expired token, or a tagged failure dict on a transient
+        provider error.
         """
-        if token == "mock_admin_token":
-            return {
-                "id": "33b56061-b629-49de-9a55-4638451978f9",
-                "email": "test.user@360ghar.com",
-                "user_metadata": {"email": "test.user@360ghar.com", "email_verified": True},
-                "app_metadata": {"provider": "email", "providers": ["email"]},
-                "phone": "+919999999999",
-                "email_verified": True,
-                "phone_verified": False,
-                "email_confirmed_at": "2026-06-18T19:35:57",
-                "phone_confirmed_at": None,
-            }
         # ── Fast path: local JWT verification ───────────────────────────────
         try:
             claims = await verify_jwt_locally(token)
@@ -464,7 +452,7 @@ class SupabaseClientManager:
         )
         return None
 
-    async def admin_link_identity(self, user_id: str, provider: str, id_token: str) -> bool:
+    async def admin_link_identity(self, user_id: str, provider: str, id_token: str) -> bool | dict[str, Any]:
         """Link an OAuth identity to an existing Supabase user via GoTrue Admin API.
 
         Returns ``True`` on success, ``False`` on a non-retryable

--- a/app/factory.py
+++ b/app/factory.py
@@ -16,7 +16,7 @@ from app.infrastructure.lifespan import create_lifespan
 from app.infrastructure.mcp import build_mcp_http_apps
 from app.infrastructure.middleware import register_middleware
 from app.infrastructure.routing import register_routes
-
+    
 logger = get_logger(__name__)
 
 # OpenAPI tag descriptions. Tag names mirror the `tags=[...]` arguments used

--- a/app/factory.py
+++ b/app/factory.py
@@ -16,7 +16,7 @@ from app.infrastructure.lifespan import create_lifespan
 from app.infrastructure.mcp import build_mcp_http_apps
 from app.infrastructure.middleware import register_middleware
 from app.infrastructure.routing import register_routes
-    
+
 logger = get_logger(__name__)
 
 # OpenAPI tag descriptions. Tag names mirror the `tags=[...]` arguments used

--- a/app/infrastructure/lifespan.py
+++ b/app/infrastructure/lifespan.py
@@ -96,6 +96,40 @@ async def _apply_pending_migrations() -> None:
                 "leases: add termination_reason",
                 "ALTER TABLE public.leases ADD COLUMN IF NOT EXISTS termination_reason text",
             ),
+            (
+                "tours: create visibility type",
+                """
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'tour_visibility') THEN
+                        CREATE TYPE tour_visibility AS ENUM ('private', 'unlisted', 'public');
+                    END IF;
+                END$$;
+                """
+            ),
+            (
+                "tours: add visibility column",
+                "ALTER TABLE public.tours ADD COLUMN IF NOT EXISTS visibility public.tour_visibility NOT NULL DEFAULT 'private'"
+            ),
+            (
+                "tours: migrate is_public to visibility",
+                """
+                UPDATE public.tours
+                SET visibility = CASE
+                    WHEN is_public = true THEN 'public'::public.tour_visibility
+                    ELSE 'private'::public.tour_visibility
+                END
+                WHERE visibility = 'private' AND is_public = true
+                """
+            ),
+            (
+                "tours: create visibility index",
+                "CREATE INDEX IF NOT EXISTS idx_tours_visibility ON public.tours(visibility)"
+            ),
+            (
+                "tours: create status_visibility index",
+                "CREATE INDEX IF NOT EXISTS idx_tours_status_visibility ON public.tours(status, visibility) WHERE deleted_at IS NULL"
+            ),
         ):
             try:
                 await conn.execute(text(sql))

--- a/app/services/property/crud.py
+++ b/app/services/property/crud.py
@@ -232,6 +232,7 @@ async def create_property(
         # hc_properties ones. Third-party URLs are soft (kept on failure).
         if image_urls:
             image_urls = await _verify_and_clean_image_urls(image_urls)
+        amenity_ids = property_dict.pop("amenity_ids", None)
         if image_urls and not property_dict.get("main_image_url"):
             property_dict["main_image_url"] = image_urls[0]
         property_dict["owner_id"] = owner_id
@@ -252,6 +253,10 @@ async def create_property(
             property_dict["location"] = wkt
 
         db_property = await repo.create(Property(**property_dict))
+
+        if amenity_ids:
+            for amenity_id in amenity_ids:
+                db.add(PropertyAmenity(property_id=db_property.id, amenity_id=amenity_id))
         if image_urls:
             await _replace_property_images(
                 db,
@@ -430,6 +435,8 @@ async def update_property(
         # update path. Third-party URLs are soft (kept on failure).
         if image_urls:
             image_urls = await _verify_and_clean_image_urls(image_urls)
+        amenity_ids_present = "amenity_ids" in update_data
+        amenity_ids = update_data.pop("amenity_ids", None)
         if image_urls_present and "main_image_url" not in update_data:
             update_data["main_image_url"] = image_urls[0] if image_urls else None
         final_property_type = update_data.get("property_type", property_obj.property_type)
@@ -486,6 +493,14 @@ async def update_property(
                 property_id=property_id,
                 image_urls=image_urls,
             )
+
+        if amenity_ids_present:
+            await db.execute(
+                sa_delete(PropertyAmenity).where(PropertyAmenity.property_id == property_id)
+            )
+            if amenity_ids:
+                for amenity_id in amenity_ids:
+                    db.add(PropertyAmenity(property_id=property_id, amenity_id=amenity_id))
 
         if (
             final_property_type in PG_FLATMATE_TYPES

--- a/app/services/property/crud.py
+++ b/app/services/property/crud.py
@@ -255,7 +255,7 @@ async def create_property(
         db_property = await repo.create(Property(**property_dict))
 
         if amenity_ids:
-            for amenity_id in amenity_ids:
+            for amenity_id in set(amenity_ids):
                 db.add(PropertyAmenity(property_id=db_property.id, amenity_id=amenity_id))
         if image_urls:
             await _replace_property_images(
@@ -499,7 +499,7 @@ async def update_property(
                 sa_delete(PropertyAmenity).where(PropertyAmenity.property_id == property_id)
             )
             if amenity_ids:
-                for amenity_id in amenity_ids:
+                for amenity_id in set(amenity_ids):
                     db.add(PropertyAmenity(property_id=property_id, amenity_id=amenity_id))
 
         if (

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -17,7 +17,7 @@ from app.core.exceptions import (
 )
 from app.core.logging import get_logger
 from app.core.utils import utc_now
-from app.models.enums import AuthMethod, UserRole
+from app.models.enums import AuthMethod, UserRole, FlatmatesProfileStatus
 from app.models.users import User
 from app.schemas.pagination import keyset_filter, keyset_payload, keyset_sort_value
 from app.schemas.user import UserUpdate
@@ -419,7 +419,7 @@ async def delete_user_account(db: AsyncSession, user: User) -> None:
     user.flatmates_work_style = None
     # Verification & status fields
     user.is_verified = False
-    user.flatmates_profile_status = None
+    user.flatmates_profile_status = FlatmatesProfileStatus.draft
     user.flatmates_onboarding_completed = False
     user.flatmates_last_active_at = None
     # Auth metadata & cross-app onboarding

--- a/tests/api/test_delete_account.py
+++ b/tests/api/test_delete_account.py
@@ -16,6 +16,7 @@ import pytest
 from httpx import AsyncClient
 
 from app.core.exceptions import ServiceUnavailableException
+from app.models.enums import FlatmatesProfileStatus
 
 # =============================================================================
 # DELETE /api/v1/users/me
@@ -186,7 +187,7 @@ class TestDeleteUserService:
 
         # Verification & status
         assert test_user.is_verified is False
-        assert test_user.flatmates_profile_status is None
+        assert test_user.flatmates_profile_status == FlatmatesProfileStatus.draft
         assert test_user.flatmates_onboarding_completed is False
         assert test_user.flatmates_last_active_at is None
         # Auth metadata


### PR DESCRIPTION
 Summary
Removed `like` and `unlike` event types from the public analytics endpoint.

Issue
The analytics endpoint accepted `like` and `unlike` events and forwarded them to `record_analytics_event()`.

These event types directly modified `tour.like_count`, allowing engagement metrics to be altered through the analytics endpoint instead of the dedicated like/unlike endpoints.

 Fix

* Removed `like` from allowed analytics events.
* Removed `unlike` from allowed analytics events.
* Like count modifications are now restricted to the dedicated endpoints.

## Verification

### Before

The analytics endpoint accepted:

* like
* unlike

### After

The analytics endpoint rejects these event types and only records analytics-related events.

### Evidence

Before and after screenshots attached below.




<img width="624" height="461" alt="image" src="https://github.com/user-attachments/assets/ef2ce21a-452a-4a12-9c16-71e17fa0bcf9" />

<img width="1065" height="670" alt="image" src="https://github.com/user-attachments/assets/896edde7-27b4-49ae-bcb8-6e3f14b50cc1" />



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/360ghar/360ghar-backend/pull/25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed like/unlike events from the public analytics endpoint and hardened auth and public API validation to prevent manipulation and reduce 500s.

- **Bug Fixes**
  - Analytics: removed `like`/`unlike`; only dedicated endpoints can change like counts.
  - Public API: validate `tour_id` as UUID; invalid IDs return 404 instead of 500.
  - Auth: removed hardcoded `mock_admin_token` bypass; safer token verification fallback with clearer provider error handling.
  - Data handling: support `amenity_ids` on property create/update (replaces relations on update); set `flatmates_profile_status` to `draft` on account deletion.

- **Migration**
  - Added `tour_visibility` enum and `tours.visibility` column; migrated from `is_public`.
  - Created indexes on `visibility` and `(status, visibility)`; applied automatically on startup.

<sup>Written for commit e127be3477307c5aae9078ce95534b575e393ade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/360ghar/360ghar-backend/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Property listings now support saving and updating amenities.
  * Public tour links now return a clear “Tour not found” response for invalid IDs.

* **Bug Fixes**
  * Improved tour visibility handling with updated startup data changes for existing records.
  * Account deletion now preserves a draft profile status instead of clearing it.
  * Authentication handling now better reflects temporary provider failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->