### PR TITLE
fix(mcp): resolve FastMCP task group initialization error on startup

### DIFF
--- a/app/infrastructure/lifespan.py
+++ b/app/infrastructure/lifespan.py
@@ -33,8 +33,8 @@ def create_lifespan(testing: bool, user_mcp_app: Any, admin_mcp_app: Any) -> Lif
         # Without this, ContextVar tokens set during lazy init in a request
         # context cannot be reset during shutdown in the server context,
         # causing "ValueError: was created in a different Context".
-        await user_mcp_app._ensure_app()
-        await admin_mcp_app._ensure_app()
+        # await user_mcp_app._ensure_app()
+        # await admin_mcp_app._ensure_app()
 
         async with user_mcp_app.lifespan(app):
             async with admin_mcp_app.lifespan(app):

--- a/app/infrastructure/mcp.py
+++ b/app/infrastructure/mcp.py
@@ -42,15 +42,16 @@ class LazyMCPHTTPApp:
     async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
         app = await self._ensure_app()
         await app(scope, receive, send)
+
     @asynccontextmanager
     async def lifespan(self, app: Any):
         self._parent_app = app
-        # Build the app NOW while parent_app is set, then start its lifespan
         inner_app = await self._ensure_app()
         if hasattr(inner_app, "lifespan"):
             self._lifespan_cm = inner_app.lifespan(app)
-            await self._lifespan_cm.__aenter__()
         try:
+            if self._lifespan_cm is not None:
+                await self._lifespan_cm.__aenter__()
             yield
         finally:
             if self._lifespan_cm is not None:

--- a/app/infrastructure/mcp.py
+++ b/app/infrastructure/mcp.py
@@ -42,10 +42,14 @@ class LazyMCPHTTPApp:
     async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
         app = await self._ensure_app()
         await app(scope, receive, send)
-
     @asynccontextmanager
     async def lifespan(self, app: Any):
         self._parent_app = app
+        # Build the app NOW while parent_app is set, then start its lifespan
+        inner_app = await self._ensure_app()
+        if hasattr(inner_app, "lifespan"):
+            self._lifespan_cm = inner_app.lifespan(app)
+            await self._lifespan_cm.__aenter__()
         try:
             yield
         finally:
@@ -62,15 +66,6 @@ class LazyMCPHTTPApp:
         async with self._lock:
             if self._app is None:
                 self._app = _build_mcp_http_app(self._server_name)
-                if self._parent_app is not None and hasattr(self._app, "lifespan"):
-                    self._lifespan_cm = self._app.lifespan(self._parent_app)
-                    await self._lifespan_cm.__aenter__()
-                elif self._parent_app is None:
-                    logger.warning(
-                        "LazyMCPHTTPApp._ensure_app called before lifespan setup; "
-                        "inner app lifespan will be skipped for server %s",
-                        self._server_name,
-                    )
         return self._app
 
 


### PR DESCRIPTION
@saksham1991999 
## Problem
Connecting 360Ghar MCP server to Claude was failing with:

RuntimeError: FastMCP's StreamableHTTPSessionManager task group was not 
initialized.

Every request to /mcp and /mcp-admin returned 500 Internal Server Error.

## Root Cause
The `LazyMCPHTTPApp._ensure_app()` was being called eagerly in `lifespan.py` 
before `_parent_app` was set. This caused the inner MCP app to build without 
a parent, so its lifespan/task group was never started.

When requests came in later, the task group was missing → 500 error.

## Changes

**`app/infrastructure/lifespan.py`**
- Removed 2 eager `_ensure_app()` calls that ran before parent app was ready

**`app/infrastructure/mcp.py`**
- Moved inner lifespan startup into `lifespan()` method where `_parent_app` 
  is already set
- Simplified `_ensure_app()` to only build the app — lifespan is now 
  handled separately in `lifespan()`

## Fix Order (now correct)
1. `lifespan()` is entered → `_parent_app` is set
2. `_ensure_app()` builds the inner MCP app
3. Inner lifespan starts → task group initializes
4. Requests come in → task group is ready ✅

## Testing
- `/health` endpoint returns 200 ✅
- `/mcp` initialize handshake returns valid JSON-RPC response ✅
- Claude MCP connection succeeds ✅

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/360ghar/360ghar-backend/pull/28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed startup ordering for `FastMCP` so the inner MCP task group initializes correctly, removing 500s on `/mcp` and `/mcp-admin`. Also ensures clean cleanup if startup fails.

- **Bug Fixes**
  - Removed eager `_ensure_app()` calls in `app/infrastructure/lifespan.py`.
  - Start inner app lifespan inside `LazyMCPHTTPApp.lifespan()` after `_parent_app` is set; `_ensure_app()` now only builds the app.
  - Call `__aenter__` inside `try/finally` to avoid dirty state on initialization failures.
  - Verified `/health` 200, `/mcp` handshake OK, and Claude MCP connection succeeds.

<sup>Written for commit 8052159b8ceedb6e3d7fac211ccfa55967998eb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/360ghar/360ghar-backend/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app startup behavior so services initialize more reliably during launch.
  * Reduced the chance of startup issues related to deferred initialization and background lifecycle handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->