### PR TITLE
Fix rent payment race condition and flatmate workflow issues

### DIFF
--- a/app/services/flatmates/conversations.py
+++ b/app/services/flatmates/conversations.py
@@ -264,6 +264,21 @@ async def create_conversation_from_payload(
         conversation.last_message_preview = payload.initial_message.strip()
         await db.flush()
         await db.refresh(message)
+
+        # --- Push notification to peer for the initial message ---
+        try:
+            from app.services.push_notification import notify_new_message
+
+            sender = await db.get(User, user_id)
+            sender_name = (sender.full_name if sender else None) or "Someone"
+            await notify_new_message(
+                db,
+                recipient_db_id=payload.peer_user_id,
+                sender_name=sender_name,
+                conversation_id=conversation.id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Initial message notification failed (best-effort): %s", exc, exc_info=True)
     else:
         await db.flush()
 

--- a/app/services/flatmates/moderation.py
+++ b/app/services/flatmates/moderation.py
@@ -525,6 +525,19 @@ async def create_report(db: AsyncSession, user_id: int, payload: ReportCreate) -
     reported_user = await db.get(User, payload.reported_user_id)
     if reported_user is None:
         raise BadRequestException(detail="Reported user not found")
+
+    # Prevent infinite duplicate reports from the same reporter against the same user
+    # to avoid database bloat and moderation queue spam.
+    existing_report = await db.execute(
+        select(UserReport.id).where(
+            UserReport.reporter_user_id == user_id,
+            UserReport.reported_user_id == payload.reported_user_id,
+            UserReport.status == UserReportStatus.open.value
+        )
+    )
+    if existing_report.scalar_one_or_none():
+        raise BadRequestException(detail="You already have an open report against this user")
+
     report = UserReport(
         reporter_user_id=user_id,
         reported_user_id=payload.reported_user_id,

--- a/app/services/pm_rent.py
+++ b/app/services/pm_rent.py
@@ -229,7 +229,10 @@ async def record_rent_payment(
     if amount_paid <= 0:
         raise BadRequestException(detail="amount_paid must be > 0")
 
-    charge = await db.get(RentCharge, charge_id)
+    # Acquire a row-level lock to prevent concurrent payment requests
+    # from interleaving and corrupting the outstanding balance calculation.
+    stmt = select(RentCharge).where(RentCharge.id == charge_id).with_for_update()
+    charge = (await db.execute(stmt)).scalar_one_or_none()
     if not charge:
         raise NotFoundException(detail="Rent charge not found")
 


### PR DESCRIPTION
This PR addresses three independent backend issues affecting the Property Management and Flatmates modules. These changes improve data consistency under concurrent requests, restore expected notification behavior for new conversations, and prevent moderation queue spam from duplicate reports.

The fixes focus on production reliability without introducing breaking API changes.

Prevent race condition during rent payment processing
Problem
The rent payment flow updates a RentCharge status (pending → partial → paid) after calculating the total amount paid against a charge.

Previously, the service loaded the RentCharge without acquiring a row-level lock.

Under PostgreSQL's default READ COMMITTED isolation level, concurrent payment requests could interleave in the following way:

Request A loads the charge.
Request B loads the same charge.
Both requests insert separate payments.
Each transaction computes the payment total before seeing the other's uncommitted payment.
Both conclude that the charge is only partially paid.
Both update the charge status to partial.
After both commits, the database contains the full payment amount, but the charge status remains incorrect.

This results in inconsistent financial state where the ledger is correct but the rent charge status is permanently stale.

Solution

The service now acquires a row-level lock on the RentCharge before processing payments using:

SELECT ... FOR UPDATE

This serializes concurrent payment requests for the same charge, ensuring that:

only one transaction updates the charge at a time,
payment aggregation always reflects committed data,
the final charge status is calculated correctly.
Result
Prevents stale payment status.
Eliminates lost-update style race conditions.
Preserves financial consistency.
2. Send notifications for the first conversation message
Problem

The Flatmates module supported two messaging flows:

existing conversations (send_message)
creating a new conversation with an initial message (create_conversation_from_payload)

Only send_message dispatched push notifications.

When a user created a brand-new conversation and included an initial message, the recipient never received a push notification.

The conversation and message were successfully created, but the recipient remained unaware until manually opening the application.

Solution

Notification dispatch has been added to the conversation creation flow after the initial message is successfully created.

The implementation mirrors the existing notification logic used by send_message.

The notification dispatch is wrapped in a try/except block so notification failures cannot interrupt successful conversation creation.

Result

Users now receive notifications for:

first message
subsequent messages

providing consistent messaging behavior.

Prevent duplicate open moderation reports
Problem
The moderation service allowed the same reporter to repeatedly submit identical reports against the same user.

Although the automatic moderation threshold already deduplicated reporters when calculating enforcement actions, the system still accepted unlimited duplicate reports.

This could:

spam the moderation queue,
increase unnecessary database growth,
create avoidable administrative workload.
Solution

Before creating a new report, the service now checks whether an existing open report already exists for the same:

reporter
reported user

If one exists, the request is rejected with a 400 Bad Request.

Closed reports remain unaffected.

This allows users to report the same account again in the future if a previous report has already been reviewed and resolved.

Result
Prevents duplicate open reports.
Keeps moderation queues clean.
Preserves the ability to report future incidents.
Files Updated
Property Management
app/services/pm_rent.py
Flatmates
app/services/flatmates/conversations.py
app/services/flatmates/moderation.py
Impact
Financial consistency
Prevents incorrect rent payment status caused by concurrent requests.
User experience
Ensures recipients receive notifications when a conversation begins.
Moderation
Prevents duplicate report spam while allowing future reports after previous reports are closed.
Breaking Changes

None.

No API contracts were modified.

No schema changes were introduced.

Existing endpoints remain fully backward compatible.

Notes

The fixes are intentionally minimal and targeted:

no changes to API request/response formats,
no database migrations required,
existing business logic preserved,
improved correctness under concurrent and real-world usage scenarios.

This PR focuses solely on improving backend reliability and consistency without affecting existing client integrations
<img width="1351" height="609" alt="image" src="https://github.com/user-attachments/assets/43460d92-82fa-43b8-acb3-1f5d9821e0fa" />

<img width="1310" height="551" alt="image" src="https://github.com/user-attachments/assets/93d11b8b-03ae-4ea7-9a5e-65aa10384e21" />

<img width="1327" height="465" alt="image" src="https://github.com/user-attachments/assets/f49305b5-72b9-443c-8825-122a2573c298" />


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/360ghar/360ghar-backend/pull/35">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a rent payment race condition, adds push notifications for the first message in new conversations, and blocks duplicate open moderation reports. Improves data consistency, notification reliability, and moderation queue health without API changes.

- **Bug Fixes**
  - Rent payments: Acquire row-level lock on `RentCharge` during processing (SELECT ... FOR UPDATE) to serialize concurrent updates and compute the correct status.
  - Messaging: Send a push notification after creating the initial message in a new conversation; failures are logged and don’t block creation.
  - Moderation: Reject duplicate open reports from the same reporter against the same user with 400; closed reports remain reportable later.

<sup>Written for commit ece2cd39e540ea50576e5e97146c18b1d3170577. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/360ghar/360ghar-backend/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sending an initial message in a new conversation can now trigger a notification to the other participant.
* **Bug Fixes**
  * Prevented users from submitting duplicate open reports for the same person.
  * Improved payment handling to reduce conflicts when rent charges are updated at the same time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->