### PR TITLE
fix(pricing): correct nightly rate calculation for short stay bookings

### DIFF
--- a/app/services/booking.py
+++ b/app/services/booking.py
@@ -309,9 +309,13 @@ async def calculate_pricing(db: AsyncSession, property_id: int, check_in_date: d
     if nights <= 0:
         return {"error": "Invalid date range"}
 
-    # Choose a per-night rate: prefer daily_rate, else fall back to base_price
-    per_night_rate = property_obj.daily_rate if property_obj.daily_rate is not None else property_obj.base_price
-    per_night_rate = float(per_night_rate or 0.0)
+   # Choose a per-night rate: prefer daily_rate, else derive from monthly_rent ÷ 30, else fall back to base_price ÷ 30
+    if property_obj.daily_rate is not None:
+        per_night_rate = float(property_obj.daily_rate)
+    elif property_obj.monthly_rent is not None:
+        per_night_rate = float(property_obj.monthly_rent) / 30
+    else:
+        per_night_rate = float(property_obj.base_price or 0.0) / 30
 
     if per_night_rate <= 0:
         return {"error": "Property has no valid rate configured"}


### PR DESCRIPTION
## Summary
Fixes a critical pricing bug in the `calculate_pricing` function where
`base_price` (monthly/sale price) was being used directly as the nightly
rate for short stay bookings, resulting in ~30x inflated prices.

## Problem
When a property had `daily_rate = None`, the fallback was `base_price`
which represents the monthly/sale price of the property — not a daily rate.
This caused the nightly rate to be set to the full monthly price, making
a 4-night stay cost as much as 4 months of rent.

**Example (Property ID: 85 — Godrej Nest, Sector 85):**
| | Before (Bug) | After (Fix) |
|--|--|--|
| `base_rate_per_night` | ₹58,40,090 ❌ | ₹1,94,670 ✅ |
| `subtotal (4 nights)` | ₹2,33,60,360 ❌ | ₹7,78,680 ✅ |
| `taxes (18%)` | ₹42,04,864 ❌ | ₹1,40,162 ✅ |
| `service charge (5%)` | ₹11,68,018 ❌ | ₹38,934 ✅ |
| **`final_total`** | **₹2,87,33,242 ❌** | **₹9,57,776 ✅** |

## Root Cause
In `calculate_pricing` inside `services/booking.py`:
```python
# ❌ Before
per_night_rate = property_obj.daily_rate if property_obj.daily_rate is not None else property_obj.base_price
per_night_rate = float(per_night_rate or 0.0)
```

## Fix
```python
# ✅ After
# Choose a per-night rate: prefer daily_rate, else derive from monthly_rent ÷ 30, else fall back to base_price ÷ 30
if property_obj.daily_rate is not None:
    per_night_rate = float(property_obj.daily_rate)
elif property_obj.monthly_rent is not None:
    per_night_rate = float(property_obj.monthly_rent) / 30
else:
    per_night_rate = float(property_obj.base_price or 0.0) / 30
```

## Files Changed
- `services/booking.py` — updated `calculate_pricing` function (2 lines + 1 comment)

## Type of Change
- [x] Bug fix (non-breaking change)

## How to Test
1. Call `bookings_get_pricing` with a property that has `daily_rate = None`
2. Verify `base_rate_per_night` = `monthly_rent / 30`
3. Verify `final_total` is correctly calculated for the number of nights

## Related
- Affects `bookings_get_pricing` MCP tool
- Affects `bookings_create` MCP tool

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nightly rate calculation for short stays by using `daily_rate`, else `monthly_rent / 30`, else `base_price / 30`. Prevents inflated totals when `daily_rate` is missing.

- **Bug Fixes**
  - Updated `calculate_pricing` in `app/services/booking.py` to derive the per-night rate with the order: `daily_rate` → `monthly_rent / 30` → `base_price / 30`.

<sup>Written for commit 83f9cdf7830c89701e743267a21df7351f338ddb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/360ghar/360ghar-backend/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated booking price calculations to use a more consistent nightly rate.
  * When available, daily rates are still used; otherwise monthly rent and base price are now converted into a per-night amount before totals are computed.
  * This may affect booking totals, including related fees and taxes, for properties that use monthly or base pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->