### PR TITLE
fix: session commit tracking, Windows event loop, and DOB coercion

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -13,7 +13,7 @@ from sqlalchemy import event
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import TimeoutError as SATimeoutError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy.orm import DeclarativeBase, Session
 from sqlalchemy.pool import NullPool
 
 from app.config import settings
@@ -276,6 +276,37 @@ AsyncSessionLocalBG = async_sessionmaker(
     autocommit=False,
 )
 
+# After ``flush()``, SQLAlchemy clears ``session.new`` / ``dirty`` / ``deleted``
+# even though the transaction still has uncommitted DML. Relying only on those
+# collections caused flatmate property creates (which always flush after
+# prescreen) to return HTTP 200 and then **roll back** on session close — the
+# listing vanished from GET /properties/me after restart.
+_SESSION_NEEDS_COMMIT_KEY = "needs_commit"
+
+
+@event.listens_for(Session, "after_flush")
+def _mark_session_needs_commit(session: Session, _flush_context) -> None:
+    session.info[_SESSION_NEEDS_COMMIT_KEY] = True
+
+
+@event.listens_for(Session, "after_commit")
+def _clear_session_needs_commit_on_commit(session: Session) -> None:
+    session.info.pop(_SESSION_NEEDS_COMMIT_KEY, None)
+
+
+@event.listens_for(Session, "after_rollback")
+def _clear_session_needs_commit_on_rollback(session: Session) -> None:
+    session.info.pop(_SESSION_NEEDS_COMMIT_KEY, None)
+
+
+def _session_needs_commit(session: AsyncSession | Session) -> bool:
+    """True when this request mutated DB state that still needs a commit."""
+    sync = getattr(session, "sync_session", session)
+    if bool(getattr(sync, "new", None) or getattr(sync, "dirty", None) or getattr(sync, "deleted", None)):
+        return True
+    info = getattr(sync, "info", None) or {}
+    return bool(info.get(_SESSION_NEEDS_COMMIT_KEY))
+
 
 # ── FastAPI dependencies ───────────────────────────────────────────────────────
 def _db_unavailable(exc: BaseException, *, error_code: str) -> ServiceUnavailableException:
@@ -351,13 +382,9 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
         await session.rollback()
         raise
     else:
-        # Commit only if the session actually has pending changes.
-        # Read-only requests (GETs, detail views) should not force a
-        # write transaction against the database / PgBouncer. Services
-        # that explicitly call ``await session.commit()`` are unaffected
-        # because by the time we reach this branch those changes have
-        # already been committed and the session is clean.
-        if session.new or session.dirty or session.deleted:
+        # Commit only if the request mutated state. Must account for flushes
+        # (see ``_session_needs_commit``) — not just UoW collections.
+        if _session_needs_commit(session):
             await session.commit()
     finally:
         hold_time = time.monotonic() - session_start
@@ -391,7 +418,7 @@ async def get_bg_db() -> AsyncGenerator[AsyncSession, None]:
             raise
         else:
             # Only commit if the background task actually mutated state.
-            if session.new or session.dirty or session.deleted:
+            if _session_needs_commit(session):
                 await session.commit()
 
 

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -285,7 +285,7 @@ _SESSION_NEEDS_COMMIT_KEY = "needs_commit"
 
 
 @event.listens_for(Session, "after_flush")
-def _mark_session_needs_commit(session: Session, _flush_context) -> None:
+def _mark_session_needs_commit(session: Session, _flush_context: object) -> None:
     session.info[_SESSION_NEEDS_COMMIT_KEY] = True
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
+
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 import sentry_sdk
 import sentry_sdk.integrations.fastapi

--- a/app/services/property/crud.py
+++ b/app/services/property/crud.py
@@ -282,6 +282,12 @@ async def create_property(
         if image_urls:
             _schedule_async_image_verification(db_property.id, image_urls)
 
+        # Explicit commit so create cannot rely solely on get_db's dirty-check.
+        # Flatmate path flushes prescreen metadata which clears UoW collections;
+        # without a commit here (and the needs_commit session flag in get_db),
+        # the request returned 200 then rolled back — listings vanished on reload.
+        await db.commit()
+
         logger.info("Property created successfully with ID %s", db_property.id)
         return PropertySchema.model_validate(property_with_relations)
     except Exception as e:

--- a/app/services/property/crud.py
+++ b/app/services/property/crud.py
@@ -277,16 +277,14 @@ async def create_property(
         if property_with_relations is None:
             raise PropertyNotFoundException(property_id=db_property.id)
 
-        # Belt-and-suspenders: async re-verification after commit in case the
-        # sync check was skipped or a URL goes bad between insert and serve.
-        if image_urls:
-            _schedule_async_image_verification(db_property.id, image_urls)
-
         # Explicit commit so create cannot rely solely on get_db's dirty-check.
         # Flatmate path flushes prescreen metadata which clears UoW collections;
         # without a commit here (and the needs_commit session flag in get_db),
         # the request returned 200 then rolled back — listings vanished on reload.
         await db.commit()
+
+        if image_urls:
+            _schedule_async_image_verification(db_property.id, image_urls)
 
         logger.info("Property created successfully with ID %s", db_property.id)
         return PropertySchema.model_validate(property_with_relations)

--- a/app/services/user.py
+++ b/app/services/user.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from datetime import date, datetime, time, timezone
 from typing import Any
 
 from sqlalchemy import and_, func, or_, select, text
@@ -26,6 +27,26 @@ from app.services.auth_user_cache import invalidate_auth_user
 from app.utils.validators import ValidationUtils
 
 logger = get_logger(__name__)
+
+
+def _coerce_date_of_birth_for_storage(value: Any) -> Any:
+    """Normalize profile DOB for the User.date_of_birth DateTime column.
+
+    ``UserUpdate.date_of_birth`` is a ``date`` (ISO ``YYYY-MM-DD`` from clients),
+    but the ORM column is ``DateTime(timezone=True)``. Assigning a bare ``date``
+    can fail or bind inconsistently under async SQLAlchemy / PostgreSQL, which
+    leaves the profile_completion gate stuck after an apparently successful
+    ``PUT /users/me``. Store midnight-UTC instead.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    if isinstance(value, date):
+        return datetime.combine(value, time.min, tzinfo=timezone.utc)
+    return value
 
 
 def _normalize_phone(phone: str | None) -> str | None:
@@ -986,9 +1007,16 @@ async def update_user(
                 raise BadRequestException(
                     detail="profile_image_url must be an absolute http(s) URL"
                 )
+            if field == "date_of_birth":
+                value = _coerce_date_of_birth_for_storage(value)
             setattr(user, field, value)
 
         await db.flush()
+        # Commit before the HTTP response is returned. FastAPI runs `get_db`
+        # cleanup *after* the response is sent, so a follow-up
+        # GET /users/me/auth-state from the client can race an uncommitted
+        # flush and still report profile_completion (missing full_name/DOB).
+        await db.commit()
         await db.refresh(user)
         logger.info("User %s updated successfully", user_id)
 

--- a/run.py
+++ b/run.py
@@ -92,7 +92,7 @@ if __name__ == "__main__":
 
     logger.info(f"Starting uvicorn with log_level={log_level}, debug={debug}")
 
-    if sys.platform == "win32":
+    if sys.platform == "win32" and not reload:
         import selectors
         selector = selectors.SelectSelector()
         loop = asyncio.SelectorEventLoop(selector)

--- a/run.py
+++ b/run.py
@@ -1,11 +1,16 @@
-import os
+import asyncio
 import logging
+import os
+import sys
 import warnings
 
 import uvicorn
-
 from dotenv import load_dotenv
+
 load_dotenv()
+
+if sys.platform == "win32":
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
 # Suppress noisy third-party deprecation warnings (uvicorn/websockets)
 warnings.filterwarnings(
@@ -67,7 +72,6 @@ if __name__ == "__main__":
     if reload:
         uvicorn_kwargs["reload_dirs"] = ["app"]
 
-    # Prefer uvloop when available and not on Windows
     if os.name != "nt":
         try:
             import uvloop  # noqa: F401
@@ -88,5 +92,13 @@ if __name__ == "__main__":
 
     logger.info(f"Starting uvicorn with log_level={log_level}, debug={debug}")
 
-    # Configure uvicorn with better reload settings
-    uvicorn.run("app.main:app", **uvicorn_kwargs)
+    if sys.platform == "win32":
+        import selectors
+        selector = selectors.SelectSelector()
+        loop = asyncio.SelectorEventLoop(selector)
+        asyncio.set_event_loop(loop)
+        config = uvicorn.Config("app.main:app", **uvicorn_kwargs)
+        server = uvicorn.Server(config)
+        loop.run_until_complete(server.serve())
+    else:
+        uvicorn.run("app.main:app", **uvicorn_kwargs)

--- a/tests/unit/core/test_database_session.py
+++ b/tests/unit/core/test_database_session.py
@@ -16,12 +16,20 @@ from fastapi.exceptions import RequestValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-def _fake_session(*, pending: bool = False) -> MagicMock:
-    """Session mock for get_db / get_bg_db dependency tests."""
+def _fake_session(*, pending: bool = False, flushed: bool = False) -> MagicMock:
+    """Session mock for get_db / get_bg_db dependency tests.
+
+    ``pending`` simulates unflushed UoW entries (new/dirty/deleted).
+    ``flushed`` simulates post-flush uncommitted DML via session.info flag
+    (the real bug: flatmate create flushes then looked "clean").
+    """
     fake_session = MagicMock(spec=AsyncSession)
     fake_session.new = {object()} if pending else set()
     fake_session.dirty = set()
     fake_session.deleted = set()
+    fake_session.info = {"needs_commit": True} if flushed else {}
+    # AsyncSession exposes sync_session; _session_needs_commit prefers it.
+    fake_session.sync_session = fake_session
     fake_session.commit = AsyncMock()
     fake_session.rollback = AsyncMock()
     fake_session.close = AsyncMock()
@@ -95,6 +103,30 @@ async def test_get_db_commits_when_session_has_pending_changes():
     from app.core import database as db_module
 
     fake_session = _fake_session(pending=True)
+    factory = _session_factory(fake_session)
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr(db_module, "AsyncSessionLocal", factory)
+
+        gen = db_module.get_db()
+        await gen.__anext__()
+        with pytest.raises(StopAsyncIteration):
+            await gen.__anext__()
+
+    fake_session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_db_commits_after_flush_even_when_uow_looks_clean():
+    """Flushed-but-uncommitted writes (flatmate create) must still commit.
+
+    After flush(), session.new/dirty/deleted are empty. Without tracking
+    needs_commit, get_db skipped commit and rolled back on close — listings
+    disappeared from GET /properties/me after the create response.
+    """
+    from app.core import database as db_module
+
+    fake_session = _fake_session(pending=False, flushed=True)
     factory = _session_factory(fake_session)
 
     with pytest.MonkeyPatch().context() as mp:

--- a/tests/unit/core/test_database_session.py
+++ b/tests/unit/core/test_database_session.py
@@ -209,6 +209,25 @@ async def test_get_bg_db_does_not_commit_when_session_is_clean():
     fake_session.commit.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_get_bg_db_commits_after_flush_even_when_uow_looks_clean():
+    """Background dependency must commit flushed-but-uncommitted writes."""
+    from app.core import database as db_module
+
+    fake_session = _fake_session(pending=False, flushed=True)
+    factory = _session_factory(fake_session)
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr(db_module, "AsyncSessionLocalBG", factory)
+
+        gen = db_module.get_bg_db()
+        await gen.__anext__()
+        with pytest.raises(StopAsyncIteration):
+            await gen.__anext__()
+
+    fake_session.commit.assert_awaited_once()
+
+
 def test_get_db_signature_is_unchanged_async_generator():
     """Regression guard: get_db must remain an async generator dependency."""
     from app.core import database as db_module

--- a/tests/unit/services/test_user_service.py
+++ b/tests/unit/services/test_user_service.py
@@ -898,6 +898,7 @@ class TestUpdateUser:
 
         db = AsyncMock(spec=AsyncSession)
         db.flush = AsyncMock()
+        db.commit = AsyncMock()
         db.refresh = AsyncMock()
 
         with patch("app.services.user.get_user_by_id", new_callable=AsyncMock) as mock_get:
@@ -908,6 +909,40 @@ class TestUpdateUser:
 
         assert updated is target
         assert target.full_name == "Renamed"
+        db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_self_update_coerces_date_of_birth_to_utc_datetime(self):
+        """Client sends ISO date; ORM column is DateTime(timezone=True).
+
+        Without coercion, assigning a bare ``date`` can leave profile_completion
+        stuck after PUT /users/me appears to succeed.
+        """
+        from datetime import date, datetime, timezone
+
+        from app.schemas.user import UserUpdate
+        from app.services.user import update_user
+
+        target = self._make_existing_user(user_id=42, role=UserRole.user.value)
+        actor = self._make_actor(user_id=42, role=UserRole.user.value)
+        db = AsyncMock(spec=AsyncSession)
+        db.flush = AsyncMock()
+        db.commit = AsyncMock()
+        db.refresh = AsyncMock()
+
+        with patch("app.services.user.get_user_by_id", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = target
+            await update_user(
+                db,
+                target.id,
+                UserUpdate(full_name="Gate User", date_of_birth=date(2000, 1, 15)),
+                actor=actor,
+            )
+
+        assert target.full_name == "Gate User"
+        assert isinstance(target.date_of_birth, datetime)
+        assert target.date_of_birth == datetime(2000, 1, 15, tzinfo=timezone.utc)
+        db.commit.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_admin_can_update_any_user(self):


### PR DESCRIPTION
## Changes

### Session commit tracking (fixes flatmate listings vanishing)
- Add `needs_commit` session flag via SQLAlchemy `after_flush` event listener
- `get_db` and `get_bg_db` now use `_session_needs_commit()` instead of only checking UoW collections
- Fixes: flatmate property creates returned HTTP 200 but rolled back on session close because `flush()` cleared `session.new/dirty/deleted`

### Explicit commits
- `create_property`: explicit `await db.commit()` after prescreen flush
- `update_user`: explicit `await db.commit()` before response to prevent auth-state race

### DOB coercion
- `_coerce_date_of_birth_for_storage()`: converts `date` to UTC `datetime` for the `DateTime(timezone=True)` ORM column
- Fixes profile_completion gate getting stuck after PUT /users/me

### Windows compatibility
- Set `WindowsSelectorEventLoopPolicy` on win32 in `run.py` and `app/main.py`
- Use `SelectorEventLoop` explicitly for uvicorn on Windows

### Tests
- `test_get_db_commits_after_flush_even_when_uow_looks_clean`
- `test_self_update_coerces_date_of_birth_to_utc_datetime`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data persistence for newly created properties and profile updates, preventing successful changes from being lost.
  * Date-of-birth updates now consistently use a UTC timestamp, improving compatibility across time zones.
  * Fixed database transaction handling after flushed changes to ensure pending updates are committed reliably.

* **Compatibility**
  * Improved application startup and event-loop handling on Windows for more reliable operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->